### PR TITLE
Resumable errors

### DIFF
--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -25,6 +25,7 @@ library
                      , Control.Effect.NonDet
                      , Control.Effect.NonDet.Internal
                      , Control.Effect.Reader
+                     , Control.Effect.Resumable
                      , Control.Effect.State
                      , Control.Effect.Sum
                      , Control.Effect.Trace

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,16 +2,17 @@ module Control.Effect
 ( module X
 ) where
 
-import Control.Effect.Error    as X
-import Control.Effect.Fail     as X
-import Control.Effect.Fresh    as X
-import Control.Effect.Handler  as X
-import Control.Effect.Internal as X
-import Control.Effect.Lift     as X
-import Control.Effect.NonDet   as X
-import Control.Effect.Reader   as X
-import Control.Effect.State    as X
-import Control.Effect.Sum      as X
-import Control.Effect.Trace    as X
-import Control.Effect.Void     as X
-import Control.Effect.Writer   as X
+import Control.Effect.Error     as X
+import Control.Effect.Fail      as X
+import Control.Effect.Fresh     as X
+import Control.Effect.Handler   as X
+import Control.Effect.Internal  as X
+import Control.Effect.Lift      as X
+import Control.Effect.NonDet    as X
+import Control.Effect.Reader    as X
+import Control.Effect.Resumable as X
+import Control.Effect.State     as X
+import Control.Effect.Sum       as X
+import Control.Effect.Trace     as X
+import Control.Effect.Void      as X
+import Control.Effect.Writer    as X

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,1 +1,5 @@
+{-# LANGUAGE ExistentialQuantification #-}
 module Control.Effect.Resumable where
+
+data Resumable exc k
+  = forall a . Resumable (exc a) (a -> k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -5,6 +5,7 @@ module Control.Effect.Resumable
 , SomeError(..)
 , runResumable
 , ResumableH(..)
+, runResumableWith
 ) where
 
 import Control.Effect.Handler
@@ -75,6 +76,13 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
   gen a = ResumableH (gen (Right a))
   alg = algE \/ (ResumableH . alg . handle (Right ()) (either (gen . Left) runResumableH))
     where algE (Resumable err _) = ResumableH (gen (Left (SomeError err)))
+
+
+runResumableWith :: Carrier (Resumable err :+: sig) (carrier m)
+                 => (carrier m a -> m a)
+                 -> Eff (carrier m) a
+                 -> m a
+runResumableWith with = with . interpret
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -44,6 +44,8 @@ instance (Show1 err) => Show (SomeError err) where
 
 
 -- | Run a 'Resumable' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
+--
+--   prop> run (runResumable (pure a)) == Right @(SomeError Identity) @Int a
 runResumable :: Effectful sig m => Eff (ResumableH err m) a -> m (Either (SomeError err) a)
 runResumable = runResumableH . interpret
 
@@ -57,6 +59,7 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
 
 -- $setup
 -- >>> :seti -XFlexibleContexts
+-- >>> :seti -XTypeApplications
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
 -- >>> import Data.Functor.Identity

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -49,7 +49,7 @@ instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 
 instance (Show1 err) => Show (SomeError err) where
-  showsPrec num (SomeError err) = liftShowsPrec (const (const id)) (const id) num err
+  showsPrec d (SomeError err) = showsUnaryWith (liftShowsPrec (const (const id)) (const id)) "SomeError" d err
 
 
 -- | Run a 'Resumable' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -23,7 +23,7 @@ instance HFunctor (Resumable err) where
 instance Effect (Resumable err) where
   handle state handler (Resumable err k) = Resumable err (handler . (<$ state) . k)
 
--- | Throw an exception which can be resumed with a value of its result type.
+-- | Throw an error which can be resumed with a value of its result type.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) == Left (SomeError (Identity a))
 throwResumable :: (Member (Resumable err) sig, Carrier sig m) => err a -> m a

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -82,6 +82,11 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.
 --
 --   Note that this may be less efficient than defining a specialized carrier type and instance specifying the handler’s behaviour directly. Performance-critical code may wish to do that to maximize the opportunities for fusion and inlining.
+--
+--   >>> data Err a where Err :: Int -> Err Int
+--
+--   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (pure a)) == a
+--   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (throwResumable (Err a))) == 1 + a
 runResumableWith :: (Carrier sig m, Monad m)
                  => (forall x . err x -> m x)
                  -> Eff (ResumableWithH err m) a
@@ -102,6 +107,7 @@ instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableW
 
 -- $setup
 -- >>> :seti -XFlexibleContexts
+-- >>> :seti -XGADTs
 -- >>> :seti -XTypeApplications
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -12,3 +12,6 @@ deriving instance Functor (Resumable exc m)
 
 instance HFunctor (Resumable exc) where
   hfmap _ (Resumable exc k) = Resumable exc k
+
+instance Effect (Resumable exc) where
+  handle state handler (Resumable exc k) = Resumable exc (handler . (<$ state) . k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -23,5 +23,5 @@ throwResumable :: (Member (Resumable exc) sig, Carrier sig m) => exc a -> m a
 throwResumable exc = send (Resumable exc gen)
 
 
-data SomeExc exc
+data SomeExc (exc :: * -> *)
   = forall a . SomeExc (exc a)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -36,6 +36,9 @@ data SomeExc (exc :: * -> *)
 instance Eq1 exc => Eq (SomeExc exc) where
   SomeExc exc1 == SomeExc exc2 = liftEq (const (const True)) exc1 exc2
 
+instance Ord1 exc => Ord (SomeExc exc) where
+  SomeExc exc1 `compare` SomeExc exc2 = liftCompare (const (const EQ)) exc1 exc2
+
 instance (Show1 exc) => Show (SomeExc exc) where
   showsPrec num (SomeExc exc) = liftShowsPrec (const (const id)) (const id) num exc
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -79,6 +79,11 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
 
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given 'Carrier' instance.
+--
+--   The passed function should be the eliminator for the carrier type, e.g. the record selector for a @newtype@. While this is less convenient than simply passing in a higher-order function with which to resume errors, defining a carrier @newtype@ has two major advantages:
+--
+--   1. It works, and
+--   2. Carrier algebras are subject to fusion, making them vastly more efficient than would otherwise be possible.
 runResumableWith :: Carrier (Resumable err :+: sig) (carrier m)
                  => (carrier m a -> m a)
                  -> Eff (carrier m) a

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -34,6 +34,10 @@ throwResumable err = send (Resumable err gen)
 data SomeError (err :: * -> *)
   = forall a . SomeError (err a)
 
+-- | Equality for 'SomeError' is determined by an 'Eq1' instance for the error type.
+--
+--   prop> SomeError (Identity a) == SomeError (Identity b)
+--   prop> (SomeError (Const a) == SomeError (Const b)) == (a == b)
 instance Eq1 err => Eq (SomeError err) where
   SomeError exc1 == SomeError exc2 = liftEq (const (const True)) exc1 exc2
 
@@ -63,4 +67,5 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
 -- >>> :seti -XTypeApplications
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
+-- >>> import Data.Functor.Const
 -- >>> import Data.Functor.Identity

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -22,6 +22,7 @@ instance HFunctor (Resumable exc) where
 instance Effect (Resumable exc) where
   handle state handler (Resumable exc k) = Resumable exc (handler . (<$ state) . k)
 
+-- | Throw an exception which can be resumed with a value of its result type.
 throwResumable :: (Member (Resumable exc) sig, Carrier sig m) => exc a -> m a
 throwResumable exc = send (Resumable exc gen)
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -48,6 +48,10 @@ instance Eq1 err => Eq (SomeError err) where
 instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 
+-- | Showing for 'SomeError' is determined by a 'Show1' instance for the error type.
+--
+--   prop> show (SomeError (Identity a)) == "SomeError (Identity )"
+--   prop> show (SomeError (Const a)) == ("SomeError (Const " ++ showsPrec 11 a ")")
 instance (Show1 err) => Show (SomeError err) where
   showsPrec d (SomeError err) = showsUnaryWith (liftShowsPrec (const (const id)) (const id)) "SomeError" d err
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, PolyKinds, StandaloneDeriving #-}
 module Control.Effect.Resumable
 ( Resumable(..)
 ) where

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, StandaloneDeriving #-}
 module Control.Effect.Resumable where
 
 data Resumable exc k
   = forall a . Resumable (exc a) (a -> k)
+
+deriving instance Functor (Resumable exc)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -78,6 +78,7 @@ instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) w
     where algE (Resumable err _) = ResumableH (gen (Left (SomeError err)))
 
 
+-- | Run a 'Resumable' effect, resuming uncaught errors with a given 'Carrier' instance.
 runResumableWith :: Carrier (Resumable err :+: sig) (carrier m)
                  => (carrier m a -> m a)
                  -> Eff (carrier m) a

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -30,6 +30,7 @@ throwResumable :: (Member (Resumable err) sig, Carrier sig m) => err a -> m a
 throwResumable err = send (Resumable err gen)
 
 
+-- | An error at some existentially-quantified type index.
 data SomeError (err :: * -> *)
   = forall a . SomeError (err a)
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, PolyKinds, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, PolyKinds, StandaloneDeriving #-}
 module Control.Effect.Resumable
 ( Resumable(..)
+, throwResumable
 ) where
 
 import Control.Effect.Handler
+import Control.Effect.Sum
 
 data Resumable exc m k
   = forall a . Resumable (exc a) (a -> k)
@@ -15,3 +17,6 @@ instance HFunctor (Resumable exc) where
 
 instance Effect (Resumable exc) where
   handle state handler (Resumable exc k) = Resumable exc (handler . (<$ state) . k)
+
+throwResumable :: (Member (Resumable exc) sig, Carrier sig m) => exc a -> m a
+throwResumable exc = send (Resumable exc gen)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -36,6 +36,8 @@ data SomeError (err :: * -> *)
 
 -- | Equality for 'SomeError' is determined by an 'Eq1' instance for the error type.
 --
+--   Note that since we can’t tell whether the type indices are equal, let alone what 'Eq' instance to use for them, the comparator passed to 'liftEq' always returns 'True'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
+--
 --   prop> SomeError (Identity a) == SomeError (Identity b)
 --   prop> (SomeError (Const a) == SomeError (Const b)) == (a == b)
 instance Eq1 err => Eq (SomeError err) where
@@ -43,12 +45,16 @@ instance Eq1 err => Eq (SomeError err) where
 
 -- | Ordering for 'SomeError' is determined by an 'Ord1' instance for the error type.
 --
+--   Note that since we can’t tell whether the type indices are equal, let alone what 'Ord' instance to use for them, the comparator passed to 'liftCompare' always returns 'EQ'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
+--
 --   prop> (SomeError (Identity a) `compare` SomeError (Identity b)) == EQ
 --   prop> (SomeError (Const a) `compare` SomeError (Const b)) == (a `compare` b)
 instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 
 -- | Showing for 'SomeError' is determined by a 'Show1' instance for the error type.
+--
+--   Note that since we can’t tell what 'Show' instance to use for the type index, the functions passed to 'liftShowsPrec' always return the empty 'ShowS'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
 --
 --   prop> show (SomeError (Identity a)) == "SomeError (Identity )"
 --   prop> show (SomeError (Const a)) == ("SomeError (Const " ++ showsPrec 11 a ")")

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -3,7 +3,7 @@ module Control.Effect.Resumable
 ( Resumable(..)
 ) where
 
-data Resumable exc k
+data Resumable exc m k
   = forall a . Resumable (exc a) (a -> k)
 
-deriving instance Functor (Resumable exc)
+deriving instance Functor (Resumable exc m)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -10,6 +10,7 @@ module Control.Effect.Resumable
 import Control.Effect.Handler
 import Control.Effect.Internal
 import Control.Effect.Sum
+import Data.Functor.Classes
 
 data Resumable exc m k
   = forall a . Resumable (exc a) (a -> k)
@@ -29,6 +30,9 @@ throwResumable exc = send (Resumable exc gen)
 
 data SomeExc (exc :: * -> *)
   = forall a . SomeExc (exc a)
+
+instance Eq1 exc => Eq (SomeExc exc) where
+  SomeExc exc1 == SomeExc exc2 = liftEq (const (const True)) exc1 exc2
 
 
 runResumable :: Effectful sig m => Eff (ResumableH exc m) a -> m (Either (SomeExc exc) a)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,0 +1,1 @@
+module Control.Effect.Resumable where

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -12,46 +12,46 @@ import Control.Effect.Internal
 import Control.Effect.Sum
 import Data.Functor.Classes
 
-data Resumable exc m k
-  = forall a . Resumable (exc a) (a -> k)
+data Resumable err m k
+  = forall a . Resumable (err a) (a -> k)
 
-deriving instance Functor (Resumable exc m)
+deriving instance Functor (Resumable err m)
 
-instance HFunctor (Resumable exc) where
-  hfmap _ (Resumable exc k) = Resumable exc k
+instance HFunctor (Resumable err) where
+  hfmap _ (Resumable err k) = Resumable err k
 
-instance Effect (Resumable exc) where
-  handle state handler (Resumable exc k) = Resumable exc (handler . (<$ state) . k)
+instance Effect (Resumable err) where
+  handle state handler (Resumable err k) = Resumable err (handler . (<$ state) . k)
 
 -- | Throw an exception which can be resumed with a value of its result type.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) == Left (SomeError (Identity a))
-throwResumable :: (Member (Resumable exc) sig, Carrier sig m) => exc a -> m a
-throwResumable exc = send (Resumable exc gen)
+throwResumable :: (Member (Resumable err) sig, Carrier sig m) => err a -> m a
+throwResumable err = send (Resumable err gen)
 
 
-data SomeError (exc :: * -> *)
-  = forall a . SomeError (exc a)
+data SomeError (err :: * -> *)
+  = forall a . SomeError (err a)
 
-instance Eq1 exc => Eq (SomeError exc) where
+instance Eq1 err => Eq (SomeError err) where
   SomeError exc1 == SomeError exc2 = liftEq (const (const True)) exc1 exc2
 
-instance Ord1 exc => Ord (SomeError exc) where
+instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 
-instance (Show1 exc) => Show (SomeError exc) where
-  showsPrec num (SomeError exc) = liftShowsPrec (const (const id)) (const id) num exc
+instance (Show1 err) => Show (SomeError err) where
+  showsPrec num (SomeError err) = liftShowsPrec (const (const id)) (const id) num err
 
 
-runResumable :: Effectful sig m => Eff (ResumableH exc m) a -> m (Either (SomeError exc) a)
+runResumable :: Effectful sig m => Eff (ResumableH err m) a -> m (Either (SomeError err) a)
 runResumable = runResumableH . interpret
 
-newtype ResumableH exc m a = ResumableH { runResumableH :: m (Either (SomeError exc) a) }
+newtype ResumableH err m a = ResumableH { runResumableH :: m (Either (SomeError err) a) }
 
-instance Effectful sig m => Carrier (Resumable exc :+: sig) (ResumableH exc m) where
+instance Effectful sig m => Carrier (Resumable err :+: sig) (ResumableH err m) where
   gen a = ResumableH (gen (Right a))
   alg = algE \/ (ResumableH . alg . handle (Right ()) (either (gen . Left) runResumableH))
-    where algE (Resumable exc _) = ResumableH (gen (Left (SomeError exc)))
+    where algE (Resumable err _) = ResumableH (gen (Left (SomeError err)))
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -43,6 +43,7 @@ instance (Show1 err) => Show (SomeError err) where
   showsPrec num (SomeError err) = liftShowsPrec (const (const id)) (const id) num err
 
 
+-- | Run a 'Resumable' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
 runResumable :: Effectful sig m => Eff (ResumableH err m) a -> m (Either (SomeError err) a)
 runResumable = runResumableH . interpret
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -41,6 +41,10 @@ data SomeError (err :: * -> *)
 instance Eq1 err => Eq (SomeError err) where
   SomeError exc1 == SomeError exc2 = liftEq (const (const True)) exc1 exc2
 
+-- | Ordering for 'SomeError' is determined by an 'Ord1' instance for the error type.
+--
+--   prop> (SomeError (Identity a) `compare` SomeError (Identity b)) == EQ
+--   prop> (SomeError (Const a) `compare` SomeError (Const b)) == (a `compare` b)
 instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -3,7 +3,12 @@ module Control.Effect.Resumable
 ( Resumable(..)
 ) where
 
+import Control.Effect.Handler
+
 data Resumable exc m k
   = forall a . Resumable (exc a) (a -> k)
 
 deriving instance Functor (Resumable exc m)
+
+instance HFunctor (Resumable exc) where
+  hfmap _ (Resumable exc k) = Resumable exc k

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -2,6 +2,7 @@
 module Control.Effect.Resumable
 ( Resumable(..)
 , throwResumable
+, SomeExc(..)
 ) where
 
 import Control.Effect.Handler
@@ -20,3 +21,7 @@ instance Effect (Resumable exc) where
 
 throwResumable :: (Member (Resumable exc) sig, Carrier sig m) => exc a -> m a
 throwResumable exc = send (Resumable exc gen)
+
+
+data SomeExc exc
+  = forall a . SomeExc (exc a)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, StandaloneDeriving #-}
-module Control.Effect.Resumable where
+module Control.Effect.Resumable
+( Resumable(..)
+) where
 
 data Resumable exc k
   = forall a . Resumable (exc a) (a -> k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -12,6 +12,7 @@ import Control.Effect.Internal
 import Control.Effect.Sum
 import Data.Functor.Classes
 
+-- | Errors which can be resumed with values of some existentially-quantified type.
 data Resumable err m k
   = forall a . Resumable (err a) (a -> k)
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -34,6 +34,9 @@ data SomeExc (exc :: * -> *)
 instance Eq1 exc => Eq (SomeExc exc) where
   SomeExc exc1 == SomeExc exc2 = liftEq (const (const True)) exc1 exc2
 
+instance (Show1 exc) => Show (SomeExc exc) where
+  showsPrec num (SomeExc exc) = liftShowsPrec (const (const id)) (const id) num exc
+
 
 runResumable :: Effectful sig m => Eff (ResumableH exc m) a -> m (Either (SomeExc exc) a)
 runResumable = runResumableH . interpret


### PR DESCRIPTION
This PR defines a `Resumable` effect type and handlers, and an existentially-quantified `SomeError` type suitable for wrapping type-indexed errors.

- [x] Defines a `Resumable` effect.
- [x] Defines a `runResumable` handler.
- [x] Defines a `SomeError` hiding its error type’s index.
- [x] Defines a `runResumableWith` handler parameterized by a higher-order effect handler.