### PR TITLE
Define `hmap` as `coerce` where possible.

### DIFF
--- a/src/Control/Effect/Fail/Internal.hs
+++ b/src/Control/Effect/Fail/Internal.hs
@@ -11,6 +11,7 @@ newtype Fail m k = Fail String
 
 instance HFunctor Fail where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect Fail where
   handle _ _ = coerce

--- a/src/Control/Effect/Fail/Internal.hs
+++ b/src/Control/Effect/Fail/Internal.hs
@@ -15,3 +15,4 @@ instance HFunctor Fail where
 
 instance Effect Fail where
   handle _ _ = coerce
+  {-# INLINE handle #-}

--- a/src/Control/Effect/Fail/Internal.hs
+++ b/src/Control/Effect/Fail/Internal.hs
@@ -4,12 +4,13 @@ module Control.Effect.Fail.Internal
 ) where
 
 import Control.Effect.Handler
+import Data.Coerce
 
 newtype Fail m k = Fail String
   deriving (Functor)
 
 instance HFunctor Fail where
-  hmap _ (Fail s) = Fail s
+  hmap _ = coerce
 
 instance Effect Fail where
-  handle _ _ (Fail s) = Fail s
+  handle _ _ = coerce

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -11,6 +11,7 @@ newtype Lift sig m k = Lift { unLift :: sig k }
 
 instance Functor sig => HFunctor (Lift sig) where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Functor sig => Effect (Lift sig) where
   handle state handler (Lift op) = Lift (fmap (handler . (<$ state)) op)

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -4,12 +4,13 @@ module Control.Effect.Lift.Internal
 ) where
 
 import Control.Effect.Handler
+import Data.Coerce
 
 newtype Lift sig m k = Lift { unLift :: sig k }
   deriving (Functor)
 
 instance Functor sig => HFunctor (Lift sig) where
-  hmap _ (Lift op) = Lift op
+  hmap _ = coerce
 
 instance Functor sig => Effect (Lift sig) where
   handle state handler (Lift op) = Lift (fmap (handler . (<$ state)) op)

--- a/src/Control/Effect/NonDet/Internal.hs
+++ b/src/Control/Effect/NonDet/Internal.hs
@@ -13,6 +13,7 @@ data NonDet m k
 
 instance HFunctor NonDet where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect NonDet where
   handle _     _       Empty      = Empty

--- a/src/Control/Effect/NonDet/Internal.hs
+++ b/src/Control/Effect/NonDet/Internal.hs
@@ -4,6 +4,7 @@ module Control.Effect.NonDet.Internal
 ) where
 
 import Control.Effect.Handler
+import Data.Coerce
 
 data NonDet m k
   = Empty
@@ -11,8 +12,7 @@ data NonDet m k
   deriving (Functor)
 
 instance HFunctor NonDet where
-  hmap _ Empty      = Empty
-  hmap _ (Choose k) = Choose k
+  hmap _ = coerce
 
 instance Effect NonDet where
   handle _     _       Empty      = Empty

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -13,6 +13,7 @@ module Control.Effect.State
 import Control.Effect.Handler
 import Control.Effect.Sum
 import Control.Effect.Internal
+import Data.Coerce
 
 data State s m k
   = Get (s -> k)
@@ -20,8 +21,7 @@ data State s m k
   deriving (Functor)
 
 instance HFunctor (State s) where
-  hmap _ (Get k)   = Get   k
-  hmap _ (Put s k) = Put s k
+  hmap _ = coerce
 
 instance Effect (State s) where
   handle state handler (Get k)   = Get   (handler . (<$ state) . k)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -22,6 +22,7 @@ data State s m k
 
 instance HFunctor (State s) where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect (State s) where
   handle state handler (Get k)   = Get   (handler . (<$ state) . k)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -23,6 +23,7 @@ data Trace m k = Trace String k
 
 instance HFunctor Trace where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect Trace where
   handle state handler (Trace s k) = Trace s (handler (k <$ state))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -15,13 +15,14 @@ import Control.Effect.Internal
 import Control.Effect.Sum
 import Control.Monad.IO.Class
 import Data.Bifunctor (first)
+import Data.Coerce
 import System.IO
 
 data Trace m k = Trace String k
   deriving (Functor)
 
 instance HFunctor Trace where
-  hmap _ (Trace s k) = Trace s k
+  hmap _ = coerce
 
 instance Effect Trace where
   handle state handler (Trace s k) = Trace s (handler (k <$ state))

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -17,6 +17,7 @@ data Writer w m k = Tell w k
 
 instance HFunctor (Writer w) where
   hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect (Writer w) where
   handle state handler (Tell w k) = Tell w (handler (k <$ state))

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -10,12 +10,13 @@ import Control.Effect.Handler
 import Control.Effect.Sum
 import Control.Effect.Internal
 import Data.Bifunctor (first)
+import Data.Coerce
 
 data Writer w m k = Tell w k
   deriving (Functor)
 
 instance HFunctor (Writer w) where
-  hmap _ (Tell w k) = Tell w k
+  hmap _ = coerce
 
 instance Effect (Writer w) where
   handle state handler (Tell w k) = Tell w (handler (k <$ state))


### PR DESCRIPTION
We can save both typing and runtime cost by defining hmap over
"simple" effect types (ones that do not use the higher-order map) to
be coerce, since the type parameter is phantom.