### PR TITLE
Add execState, evalState, and execWriter.

### DIFF
--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -7,6 +7,8 @@ module Control.Effect.State
 , modify
 , modify'
 , runState
+, evalState
+, execState
 , StateC(..)
 ) where
 
@@ -67,6 +69,19 @@ modify' f = do
 --   prop> run (runState a (pure b)) == (a, b)
 runState :: (Carrier sig m, Effect sig) => s -> Eff (StateC s m) a -> m (s, a)
 runState s m = runStateC (interpret m) s
+
+-- | Run a 'State' effect, yielding the result value and discarding the final state.
+--
+--   prop> run (evalState a (pure b)) == b
+evalState :: (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m a
+evalState s m = fmap snd (runStateC (interpret m) s)
+
+-- | Run a 'State' effect, yielding the final state and discarding the return value.
+--
+--   prop> run (execState a (pure b)) == a
+execState :: (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m s
+execState s m = fmap fst (runStateC (interpret m) s)
+
 
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -3,6 +3,7 @@ module Control.Effect.Writer
 ( Writer(..)
 , tell
 , runWriter
+, execWriter
 , WriterC(..)
 ) where
 
@@ -32,6 +33,13 @@ tell w = send (Tell w (gen ()))
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
 runWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m (w, a)
 runWriter m = runWriterC (interpret m)
+
+-- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
+--
+--   prop> run (runWriter (tell (Sum a) *> pure b)) == Sum a
+execWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
+execWriter m = fmap fst (runWriterC (interpret m))
+
 
 newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -36,7 +36,7 @@ runWriter m = runWriterC (interpret m)
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
---   prop> run (runWriter (tell (Sum a) *> pure b)) == Sum a
+--   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
 execWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
 execWriter m = fmap fst (runWriterC (interpret m))
 


### PR DESCRIPTION
As per `freer-effects` and `mtl`, these functions are handy to have so
that you don't forget an `fmap fst` or `fmap snd`.

Docs and doctests are present.