### PR TITLE
Refactor to improve legibility of instances, add generic functions

### DIFF
--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures,
   MultiParamTypeClasses, TypeOperators, UndecidableInstances, TypeApplications,
   TypeFamilyDependencies, DataKinds, LambdaCase, ScopedTypeVariables, PolyKinds,
-  RankNTypes, DefaultSignatures, AllowAmbiguousTypes #-}
+  RankNTypes, DefaultSignatures #-}
 
 module Teletype where
 
@@ -10,7 +10,6 @@ import Prelude hiding (read)
 import Control.Effect
 import Control.Monad.IO.Class
 import Data.Coerce
-import GHC.TypeLits
 import Test.Hspec
 import Test.Hspec.QuickCheck
 

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures,
+  MultiParamTypeClasses, TypeOperators, UndecidableInstances, TypeApplications,
+  TypeFamilyDependencies, DataKinds, LambdaCase, ScopedTypeVariables, PolyKinds,
+  RankNTypes, DefaultSignatures, AllowAmbiguousTypes #-}
 
 module Teletype where
 
@@ -7,19 +10,55 @@ import Prelude hiding (read)
 import Control.Effect
 import Control.Monad.IO.Class
 import Data.Coerce
+import GHC.TypeLits
 import Test.Hspec
 import Test.Hspec.QuickCheck
 
+
+-- TESTS -----------------------------------------------------------------------
+
 spec :: Spec
 spec = describe "teletype" $ do
-  prop "reads" $
-    \ line -> run (runTeletypeRet [line] read) `shouldBe` (([], []), line)
+  prop "reads" $ \line ->
+    run (handleEff @TeletypeRetH read [line])
+    `shouldBe`
+    (([], []), line)
 
   prop "writes" $
-    \ input output -> run (runTeletypeRet input (write output)) `shouldBe` ((input, [output]), ())
+    \input output ->
+      run (handleEff @TeletypeRetH (write output) input)
+      `shouldBe`
+      ((input, [output]), ())
 
   prop "writes multiple things" $
-    \ input output1 output2 -> run (runTeletypeRet input (write output1 >> write output2)) `shouldBe` ((input, [output1, output2]), ())
+    \input output1 output2 ->
+      run (handleEff @TeletypeRetH (write output1 >> write output2) input)
+      `shouldBe`
+      ((input, [output1, output2]), ())
+
+-- GENERIC DESCRIPTIONS OF HANDLERS --------------------------------------------
+
+handleEff
+  :: forall handler sig m a. (Handler handler, Carrier sig (handler m))
+  => Eff (handler m) a -> Run handler m a
+handleEff m = runHandler (interpret @sig m)
+
+class Handler (handler :: (* -> *) -> * -> *) where
+  -- All you need to do is instantiate this type family...
+  type Run handler (m :: * -> *) (a :: *) :: *
+
+  runHandler :: forall m a. handler m a -> Run handler m a
+  default runHandler
+    :: Coercible (handler m a) (Run handler m a)
+    => handler m a -> Run handler m a
+  runHandler = coerce
+  handler :: forall m a. Run handler m a -> handler m a
+  default handler
+    :: Coercible (handler m a) (Run handler m a)
+    => Run handler m a -> handler m a
+  handler = coerce
+
+-- TELETYPE EFFECT -------------------------------------------------------------
 
 data Teletype (m :: * -> *) k
   = Read (String -> k)
@@ -36,35 +75,56 @@ read = send (Read gen)
 write :: (Member Teletype sig, Carrier sig m) => String -> m ()
 write s = send (Write s (gen ()))
 
+-- IO INTERPRETATION OF TELETYPE -----------------------------------------------
 
-runTeletypeIO :: (MonadIO m, Carrier sig m) => Eff (TeletypeIOH m) a -> m a
-runTeletypeIO = runTeletypeIOH . interpret
+newtype TeletypeIOH m a
+  = TeletypeIOH (Run TeletypeIOH m a)
 
-newtype TeletypeIOH m a = TeletypeIOH { runTeletypeIOH :: m a }
+instance Handler TeletypeIOH where
+  type Run TeletypeIOH m a = m a
 
-instance (MonadIO m, Carrier sig m) => Carrier (Teletype :+: sig) (TeletypeIOH m) where
-  gen = TeletypeIOH . gen
+instance (MonadIO m, Carrier sig m)
+  => Carrier (Teletype :+: sig) (TeletypeIOH m) where
+
+  gen = handler . gen
+
   alg = algT \/ algOther
-    where algT (Read    k) = TeletypeIOH (liftIO getLine >>= runTeletypeIOH . k)
-          algT (Write s k) = TeletypeIOH (liftIO (putStrLn s) >> runTeletypeIOH k)
-          algOther op = TeletypeIOH (alg (handlePure runTeletypeIOH op))
+    where
+      algT = handler . \case
+        Read k    -> liftIO getLine >>= runHandler . k
+        Write s k -> liftIO (putStrLn s) >> runHandler k
 
+      algOther =
+        handler . alg . handlePure (runHandler @TeletypeIOH)
 
-runTeletypeRet :: (Carrier sig m, Effect sig, Monad m) => [String] -> Eff (TeletypeRetH m) a -> m (([String], [String]), a)
-runTeletypeRet s m = runTeletypeRetH (interpret m) s
+-- PURE INTERPRETATION OF TELETYPE EFFECT --------------------------------------
 
-newtype TeletypeRetH m a = TeletypeRetH { runTeletypeRetH :: [String] -> m (([String], [String]), a) }
+newtype TeletypeRetH m a
+  = TeletypeRetH (Run TeletypeRetH m a)
 
-instance (Monad m, Carrier sig m, Effect sig) => Carrier (Teletype :+: sig) (TeletypeRetH m) where
-  gen a = TeletypeRetH (\ i -> gen ((i, []), a))
+instance Handler TeletypeRetH where
+  type Run TeletypeRetH m a = [String] -> m (([String], [String]), a)
+
+instance (Monad m, Carrier sig m, Effect sig)
+  => Carrier (Teletype :+: sig) (TeletypeRetH m) where
+
+  gen a =
+    handler $ \i -> gen ((i, []), a)
+
   alg = algT \/ algOther
-    where algT (Read    k) = TeletypeRetH (\ i -> case i of
-            []  -> runTeletypeRetH (k "") []
-            h:t -> runTeletypeRetH (k h)  t)
-          algT (Write s k) = TeletypeRetH (\ i -> do
-            ((i, out), a) <- runTeletypeRetH k i
-            pure ((i, s:out), a))
-          algOther op = TeletypeRetH (\ i -> alg (handle ((i, []), ()) mergeResults op))
-          mergeResults ((i, o), m) = do
-            ((i', o'), a) <- runTeletypeRetH m i
-            pure ((i', o ++ o'), a)
+    where
+      algT = handler . \case
+        Read k -> \case
+          []  -> runHandler (k "") []
+          h:t -> runHandler (k h)  t
+        Write s k -> \i -> do
+          ((i, out), a) <- runHandler k i
+          pure ((i, s:out), a)
+
+      algOther op =
+        handler @_ @m $ \i ->
+          alg (handle ((i, []), ()) mergeResults op)
+
+      mergeResults ((i, o), m) = do
+        ((i', o'), a) <- runHandler m i
+        pure ((i', o ++ o'), a)


### PR DESCRIPTION
@patrickt said he wanted `Carrier` instance declarations to be less noisy, and I agreed that they could be less so. Here's what I cooked up :)

Notice the pattern when defining an effect handler `Foo`: define an instance of `Handler` for `Foo` that provides only the type instance `Run`, then make a newtype `Foo` that exactly wraps a `Run Foo m a`. For instance, you'll see below:

```haskell
newtype TeletypeIOH m a
  = TeletypeIOH (Run TeletypeIOH m a)

instance Handler TeletypeIOH where
  type Run TeletypeIOH m a = m a
```

Doing things this way auto-derives appropriate instances of `runHandler` and `handler`, which are type-constrained `coerce`. The particular constraints on their types mean that inference goes through with no need to give a top-level annotation for anything in a `where`-clause in these definitions.

Uhm, also, I might not actually need all these language extensions, but it's late enough at night that I'm gonna leave them in and look at pruning them later :P