### PR TITLE
IO

### DIFF
--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -40,6 +40,7 @@ test-suite test
   type:                exitcode-stdio-1.0
   main-is:             Spec.hs
   other-modules:       Control.Effect.Spec
+                     , Control.Effect.IO.Spec
                      , Control.Effect.NonDet.Spec
   build-depends:       base >=4.11 && <4.12
                      , higher-order-effects

--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -20,6 +20,7 @@ library
                      , Control.Effect.Fresh
                      , Control.Effect.Handler
                      , Control.Effect.Internal
+                     , Control.Effect.IO
                      , Control.Effect.Lift
                      , Control.Effect.Lift.Internal
                      , Control.Effect.NonDet

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -7,6 +7,7 @@ import Control.Effect.Fail      as X
 import Control.Effect.Fresh     as X
 import Control.Effect.Handler   as X
 import Control.Effect.Internal  as X
+import Control.Effect.IO        as X
 import Control.Effect.Lift      as X
 import Control.Effect.NonDet    as X
 import Control.Effect.Reader    as X

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -8,8 +8,8 @@ module Control.Effect.Error
 ) where
 
 import Control.Effect.Handler
-import Control.Effect.Sum
 import Control.Effect.Internal
+import Control.Effect.Sum
 import Control.Monad ((<=<))
 
 data Error exc m k

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -28,7 +28,7 @@ rethrowing m = liftIO (Exc.try m) >>= either (throwError . Exc.toException @Exc.
 --
 --   * Exceptions in @before@ and @after@ are thrown in IO.
 --   * @after@ is called on IO exceptions in @handler@, and then rethrown in IO.
---   * If @handler@ completes successfully, @after@ is called
+--   * If @handler@ completes successfully, @after@ is called.
 --
 --   Call 'catchIO' at the call site if you want to recover.
 bracket :: ( Member (Lift IO) sig

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -1,10 +1,13 @@
-{-# LANGUAGE FlexibleContexts, TypeApplications #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeApplications, UndecidableInstances #-}
 module Control.Effect.IO
 ( rethrowing
+, bracket
 ) where
 
 import Control.Effect.Error
 import Control.Effect.Handler
+import Control.Effect.Internal
+import Control.Effect.Lift
 import Control.Effect.Sum
 import qualified Control.Exception as Exc
 import Control.Monad.IO.Class
@@ -19,3 +22,36 @@ rethrowing :: ( Member (Error Exc.SomeException) sig
            => IO a
            -> m a
 rethrowing m = liftIO (Exc.try m) >>= either (throwError . Exc.toException @Exc.SomeException) pure
+
+
+-- | The semantics of @bracket before after handler@ are as follows:
+--
+--   * Exceptions in @before@ and @after@ are thrown in IO.
+--   * @after@ is called on IO exceptions in @handler@, and then rethrown in IO.
+--   * If @handler@ completes successfully, @after@ is called
+--
+--   Call 'catchIO' at the call site if you want to recover.
+bracket :: ( Member (Lift IO) sig
+           , Carrier sig m
+           , MonadIO m
+           )
+        => IO a
+        -> (a -> IO b)
+        -> (a -> Eff (BracketC m) c)
+        -> m c
+bracket before after action = do
+  a <- liftIO before
+  let cleanup = after a
+  res <- runBracketC cleanup (interpret (action a))
+  res <$ liftIO cleanup
+
+newtype BracketC m a = BracketC (forall b . IO b -> m a)
+
+runBracketC :: IO b -> BracketC m a -> m a
+runBracketC io (BracketC m) = m io
+
+instance (Member (Lift IO) sig, Carrier sig m, MonadIO m) => Carrier sig (BracketC m) where
+  gen a = BracketC (const (gen a))
+  alg op
+    | Just (Lift m) <- prj op = BracketC (\ cleanup -> liftIO (Exc.try m) >>= either (\ exc -> liftIO cleanup >> liftIO (Exc.throwIO @Exc.SomeException exc)) (runBracketC cleanup))
+    | otherwise               = BracketC (\ cleanup -> alg (handlePure (runBracketC cleanup) op))

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -9,8 +9,9 @@ import Control.Effect.Sum
 import qualified Control.Exception as Exc
 import Control.Monad.IO.Class
 
--- | Lift an 'IO' action into 'Eff', catching and rethrowing any exceptions it throws into an 'Error' effect.
--- If you need more granular control over the types of exceptions caught, use 'catchIO' and rethrow in the handler.
+-- | Lift an 'IO' action into a carrier, catching and rethrowing any exceptions it throws into an 'Error' effect.
+--
+--   If you need more granular control over the types of exceptions caught, use 'catchIO' and rethrow in the handler.
 rethrowing :: ( Member (Error Exc.SomeException) sig
               , MonadIO m
               , Carrier sig m

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -1,1 +1,20 @@
-module Control.Effect.IO where
+{-# LANGUAGE FlexibleContexts, TypeApplications #-}
+module Control.Effect.IO
+( rethrowing
+) where
+
+import Control.Effect.Error
+import Control.Effect.Handler
+import Control.Effect.Sum
+import qualified Control.Exception as Exc
+import Control.Monad.IO.Class
+
+-- | Lift an 'IO' action into 'Eff', catching and rethrowing any exceptions it throws into an 'Error' effect.
+-- If you need more granular control over the types of exceptions caught, use 'catchIO' and rethrow in the handler.
+rethrowing :: ( Member (Error Exc.SomeException) sig
+              , MonadIO m
+              , Carrier sig m
+              )
+           => IO a
+           -> m a
+rethrowing m = liftIO (Exc.try m) >>= either (throwError . Exc.toException @Exc.SomeException) pure

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -2,6 +2,7 @@
 module Control.Effect.IO
 ( catchIO
 , bracket
+, BracketC(..)
 ) where
 
 import Control.Effect.Handler

--- a/src/Control/Effect/IO.hs
+++ b/src/Control/Effect/IO.hs
@@ -1,0 +1,1 @@
+module Control.Effect.IO where

--- a/test/Control/Effect/IO/Spec.hs
+++ b/test/Control/Effect/IO/Spec.hs
@@ -1,6 +1,21 @@
+{-# LANGUAGE GADTs, ScopedTypeVariables, TypeOperators #-}
 module Control.Effect.IO.Spec where
 
+import Control.Effect
+import qualified Control.Exception as Exc
+import Data.Bifunctor (first)
+import Data.Typeable
 import Test.Hspec
 
 spec :: Spec
-spec = pure ()
+spec = do
+  describe "rethrowing" $ do
+    it "bridges exceptions into Error effects" $ do
+      exc <- runM (runError (rethrowing (error "error") *> pure ()))
+      first extract exc `shouldBe` Left (Just "error")
+
+
+extract :: Exc.SomeException -> Maybe String
+extract (Exc.SomeException (exc :: e)) = case eqT :: Maybe (e :~: Exc.ErrorCall) of
+  Just Refl | Exc.ErrorCall str <- exc -> Just str
+  _                                    -> Nothing

--- a/test/Control/Effect/IO/Spec.hs
+++ b/test/Control/Effect/IO/Spec.hs
@@ -1,0 +1,6 @@
+module Control.Effect.IO.Spec where
+
+import Test.Hspec
+
+spec :: Spec
+spec = pure ()

--- a/test/Control/Effect/IO/Spec.hs
+++ b/test/Control/Effect/IO/Spec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, ScopedTypeVariables, TypeOperators #-}
+{-# LANGUAGE GADTs, ScopedTypeVariables, TypeApplications, TypeOperators #-}
 module Control.Effect.IO.Spec where
 
 import Control.Effect
@@ -11,7 +11,7 @@ spec :: Spec
 spec = do
   describe "rethrowing" $ do
     it "bridges exceptions into Error effects" $ do
-      exc <- runM (runError (rethrowing (error "error") *> pure ()))
+      exc <- runM (runError ((error "error" `catchIO` (throwError . Exc.toException @Exc.SomeException)) *> pure ()))
       first extract exc `shouldBe` Left (Just "error")
 
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,10 +1,12 @@
 module Main where
 
 import qualified Control.Effect.Spec
+import qualified Control.Effect.IO.Spec
 import qualified Control.Effect.NonDet.Spec
 import Test.Hspec
 
 main :: IO ()
 main = hspec . parallel $ do
   describe "Control.Effect.Spec" Control.Effect.Spec.spec
+  describe "Control.Effect.IO.Spec" Control.Effect.IO.Spec.spec
   describe "Control.Effect.NonDet.Spec" Control.Effect.NonDet.Spec.spec


### PR DESCRIPTION
This PR adds a couple of helpers for using `IO` actions in effectful contexts. These were ported from https://github.com/joshvera/effects, tho `rethrowing` was replaced with `catchIO`. IIRC `bracket` was originally implemented by @patrickt.