### PR TITLE
Carrier method renaming

### DIFF
--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -31,10 +31,10 @@ instance HFunctor Teletype where
   {-# INLINE hmap #-}
 
 read :: (Member Teletype sig, Carrier sig m) => m String
-read = send (Read gen)
+read = send (Read ret)
 
 write :: (Member Teletype sig, Carrier sig m) => String -> m ()
-write s = send (Write s (gen ()))
+write s = send (Write s (ret ()))
 
 
 runTeletypeIO :: (MonadIO m, Carrier sig m) => Eff (TeletypeIOC m) a -> m a
@@ -43,11 +43,11 @@ runTeletypeIO = runTeletypeIOC . interpret
 newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Teletype :+: sig) (TeletypeIOC m) where
-  gen = TeletypeIOC . gen
-  alg = algT \/ algOther
-    where algT (Read    k) = TeletypeIOC (liftIO getLine >>= runTeletypeIOC . k)
-          algT (Write s k) = TeletypeIOC (liftIO (putStrLn s) >> runTeletypeIOC k)
-          algOther op = TeletypeIOC (alg (handlePure runTeletypeIOC op))
+  ret = TeletypeIOC . ret
+  eff = alg \/ algOther
+    where alg (Read    k) = TeletypeIOC (liftIO getLine >>= runTeletypeIOC . k)
+          alg (Write s k) = TeletypeIOC (liftIO (putStrLn s) >> runTeletypeIOC k)
+          algOther op = TeletypeIOC (eff (handlePure runTeletypeIOC op))
 
 
 runTeletypeRet :: (Carrier sig m, Effect sig, Monad m) => [String] -> Eff (TeletypeRetC m) a -> m (([String], [String]), a)
@@ -56,15 +56,15 @@ runTeletypeRet s m = runTeletypeRetC (interpret m) s
 newtype TeletypeRetC m a = TeletypeRetC { runTeletypeRetC :: [String] -> m (([String], [String]), a) }
 
 instance (Monad m, Carrier sig m, Effect sig) => Carrier (Teletype :+: sig) (TeletypeRetC m) where
-  gen a = TeletypeRetC (\ i -> gen ((i, []), a))
-  alg = algT \/ algOther
-    where algT (Read    k) = TeletypeRetC (\ i -> case i of
+  ret a = TeletypeRetC (\ i -> ret ((i, []), a))
+  eff = alg \/ algOther
+    where alg (Read    k) = TeletypeRetC (\ i -> case i of
             []  -> runTeletypeRetC (k "") []
             h:t -> runTeletypeRetC (k h)  t)
-          algT (Write s k) = TeletypeRetC (\ i -> do
+          alg (Write s k) = TeletypeRetC (\ i -> do
             ((i, out), a) <- runTeletypeRetC k i
             pure ((i, s:out), a))
-          algOther op = TeletypeRetC (\ i -> alg (handle ((i, []), ()) mergeResults op))
+          algOther op = TeletypeRetC (\ i -> eff (handle ((i, []), ()) mergeResults op))
           mergeResults ((i, o), m) = do
             ((i', o'), a) <- runTeletypeRetC m i
             pure ((i', o ++ o'), a)

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -44,10 +44,9 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Teletype :+: sig) (TeletypeIOC m) where
   ret = TeletypeIOC . ret
-  eff = alg \/ algOther
-    where alg (Read    k) = TeletypeIOC (liftIO getLine >>= runTeletypeIOC . k)
-          alg (Write s k) = TeletypeIOC (liftIO (putStrLn s) >> runTeletypeIOC k)
-          algOther op = TeletypeIOC (eff (handlePure runTeletypeIOC op))
+  eff = TeletypeIOC . (alg \/ eff . handlePure runTeletypeIOC)
+    where alg (Read    k) = liftIO getLine >>= runTeletypeIOC . k
+          alg (Write s k) = liftIO (putStrLn s) >> runTeletypeIOC k
 
 
 runTeletypeRet :: (Carrier sig m, Effect sig, Monad m) => [String] -> Eff (TeletypeRetC m) a -> m (([String], [String]), a)

--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -22,7 +22,7 @@ library
                      , Control.Effect.Fail
                      , Control.Effect.Fail.Internal
                      , Control.Effect.Fresh
-                     , Control.Effect.Handler
+                     , Control.Effect.Carrier
                      , Control.Effect.Internal
                      , Control.Effect.Lift
                      , Control.Effect.Lift.Internal

--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -13,7 +13,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 flag build-examples
-  description: Build with optimizations on (for CI or deployment builds)
+  description: Build the examples
   default:     False
 
 library

--- a/higher-order-effects.cabal
+++ b/higher-order-effects.cabal
@@ -18,11 +18,11 @@ flag build-examples
 
 library
   exposed-modules:     Control.Effect
+                     , Control.Effect.Carrier
                      , Control.Effect.Error
                      , Control.Effect.Fail
                      , Control.Effect.Fail.Internal
                      , Control.Effect.Fresh
-                     , Control.Effect.Carrier
                      , Control.Effect.Internal
                      , Control.Effect.Lift
                      , Control.Effect.Lift.Internal

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -5,7 +5,7 @@ module Control.Effect
 import Control.Effect.Error     as X
 import Control.Effect.Fail      as X
 import Control.Effect.Fresh     as X
-import Control.Effect.Handler   as X
+import Control.Effect.Carrier   as X
 import Control.Effect.Internal  as X
 import Control.Effect.Lift      as X
 import Control.Effect.NonDet    as X

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,10 +2,10 @@ module Control.Effect
 ( module X
 ) where
 
+import Control.Effect.Carrier   as X
 import Control.Effect.Error     as X
 import Control.Effect.Fail      as X
 import Control.Effect.Fresh     as X
-import Control.Effect.Carrier   as X
 import Control.Effect.Internal  as X
 import Control.Effect.Lift      as X
 import Control.Effect.NonDet    as X

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -34,7 +34,7 @@ class HFunctor sig => Effect sig where
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'gen' and 'alg' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
   handleReturn :: a -> h a
-  alg :: sig h (h a) -> h a
+  handleEffect :: sig h (h a) -> h a
 
 
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DefaultSignatures, FunctionalDependencies, RankNTypes #-}
-module Control.Effect.Handler
+module Control.Effect.Carrier
 ( HFunctor(..)
 , Effect(..)
 , Carrier(..)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -34,6 +34,7 @@ class HFunctor sig => Effect sig where
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'ret' and 'eff' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
   ret :: a -> h a
+
   eff :: sig h (h a) -> h a
 
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -33,8 +33,8 @@ class HFunctor sig => Effect sig where
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'gen' and 'alg' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
-  handleReturn :: a -> h a
-  handleEffect :: sig h (h a) -> h a
+  ret :: a -> h a
+  eff :: sig h (h a) -> h a
 
 
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -33,6 +33,7 @@ class HFunctor sig => Effect sig where
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'ret' and 'eff' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
+  -- | Wrap a return value.
   ret :: a -> h a
 
   eff :: sig h (h a) -> h a

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -23,7 +23,7 @@ class HFunctor h where
 --   1. Be functorial in their last two arguments, and
 --   2. Support threading effects in higher-order positions through using the carrier’s suspended state.
 class HFunctor sig => Effect sig where
-  -- | Handle any effects in higher-order positions by threading the carrier’s state all the way through to the continuation.
+  -- | Handle any effects in a signature by threading the carrier’s state all the way through to the continuation.
   handle :: Functor f
          => f ()
          -> (forall x . f (m x) -> n (f x))

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -36,6 +36,7 @@ class HFunctor sig => Carrier sig h | h -> sig where
   -- | Wrap a return value.
   ret :: a -> h a
 
+  -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   eff :: sig h (h a) -> h a
 
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -31,7 +31,7 @@ class HFunctor sig => Effect sig where
          -> sig n (n (f a))
 
 
--- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'gen' and 'alg' methods.
+-- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'ret' and 'eff' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
   ret :: a -> h a
   eff :: sig h (h a) -> h a

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -33,7 +33,7 @@ class HFunctor sig => Effect sig where
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'gen' and 'alg' methods.
 class HFunctor sig => Carrier sig h | h -> sig where
-  gen :: a -> h a
+  handleReturn :: a -> h a
   alg :: sig h (h a) -> h a
 
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -40,7 +40,7 @@ throwError = send . Throw
 --   prop> run (runError (throwError a `catchError` pure)) == Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) == Left @Int @Int a
 catchError :: (Member (Error exc) sig, Carrier sig m) => m a -> (exc -> m a) -> m a
-catchError m h = send (Catch m h handleReturn)
+catchError m h = send (Catch m h ret)
 
 
 -- | Run an 'Error' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
@@ -52,8 +52,8 @@ runError = runErrorC . interpret
 newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
-  handleReturn a = ErrorC (pure (Right a))
-  handleEffect = algE \/ (ErrorC . handleEffect . handle (Right ()) (either (pure . Left) runErrorC))
+  ret a = ErrorC (pure (Right a))
+  eff = algE \/ (ErrorC . eff . handle (Right ()) (either (pure . Left) runErrorC))
     where algE (Throw e)     = ErrorC (pure (Left e))
           algE (Catch m h k) = ErrorC (runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k))
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -40,7 +40,7 @@ throwError = send . Throw
 --   prop> run (runError (throwError a `catchError` pure)) == Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) == Left @Int @Int a
 catchError :: (Member (Error exc) sig, Carrier sig m) => m a -> (exc -> m a) -> m a
-catchError m h = send (Catch m h gen)
+catchError m h = send (Catch m h handleReturn)
 
 
 -- | Run an 'Error' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
@@ -52,7 +52,7 @@ runError = runErrorC . interpret
 newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
-  gen a = ErrorC (pure (Right a))
+  handleReturn a = ErrorC (pure (Right a))
   alg = algE \/ (ErrorC . alg . handle (Right ()) (either (pure . Left) runErrorC))
     where algE (Throw e)     = ErrorC (pure (Left e))
           algE (Catch m h k) = ErrorC (runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k))

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -53,9 +53,9 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
   ret a = ErrorC (pure (Right a))
-  eff = ErrorC . (algE \/ eff . handle (Right ()) (either (pure . Left) runErrorC))
-    where algE (Throw e)     = pure (Left e)
-          algE (Catch m h k) = runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k)
+  eff = ErrorC . (alg \/ eff . handle (Right ()) (either (pure . Left) runErrorC))
+    where alg (Throw e)     = pure (Left e)
+          alg (Catch m h k) = runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k)
 
 
 -- $setup

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -53,9 +53,9 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
   ret a = ErrorC (pure (Right a))
-  eff = algE \/ (ErrorC . eff . handle (Right ()) (either (pure . Left) runErrorC))
-    where algE (Throw e)     = ErrorC (pure (Left e))
-          algE (Catch m h k) = ErrorC (runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k))
+  eff = ErrorC . (algE \/ eff . handle (Right ()) (either (pure . Left) runErrorC))
+    where algE (Throw e)     = pure (Left e)
+          algE (Catch m h k) = runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k)
 
 
 -- $setup

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -7,7 +7,7 @@ module Control.Effect.Error
 , ErrorC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
 import Control.Monad ((<=<))

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -53,7 +53,7 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
   handleReturn a = ErrorC (pure (Right a))
-  alg = algE \/ (ErrorC . alg . handle (Right ()) (either (pure . Left) runErrorC))
+  handleEffect = algE \/ (ErrorC . handleEffect . handle (Right ()) (either (pure . Left) runErrorC))
     where algE (Throw e)     = ErrorC (pure (Left e))
           algE (Catch m h k) = ErrorC (runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k))
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -21,9 +21,9 @@ runFail = runFailC . interpret
 newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
-  gen a = FailC (gen (Right a))
-  alg = algF \/ (FailC . alg . handle (Right ()) (either (gen . Left) runFailC))
-    where algF (Fail s) = FailC (gen (Left s))
+  handleReturn a = FailC (handleReturn (Right a))
+  alg = algF \/ (FailC . alg . handle (Right ()) (either (handleReturn . Left) runFailC))
+    where algF (Fail s) = FailC (handleReturn (Left s))
 
 
 -- $setup

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,8 +22,8 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   ret a = FailC (ret (Right a))
-  eff = algF \/ (FailC . eff . handle (Right ()) (either (ret . Left) runFailC))
-    where algF (Fail s) = FailC (ret (Left s))
+  eff = FailC . (algF \/ eff . handle (Right ()) (either (ret . Left) runFailC))
+    where algF (Fail s) = ret (Left s)
 
 
 -- $setup

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -7,7 +7,7 @@ module Control.Effect.Fail
 ) where
 
 import Control.Effect.Fail.Internal
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
 import Control.Monad.Fail

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,8 +22,8 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   ret a = FailC (ret (Right a))
-  eff = FailC . (algF \/ eff . handle (Right ()) (either (ret . Left) runFailC))
-    where algF (Fail s) = ret (Left s)
+  eff = FailC . (alg \/ eff . handle (Right ()) (either (ret . Left) runFailC))
+    where alg (Fail s) = ret (Left s)
 
 
 -- $setup

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,7 +22,7 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   handleReturn a = FailC (handleReturn (Right a))
-  alg = algF \/ (FailC . alg . handle (Right ()) (either (handleReturn . Left) runFailC))
+  handleEffect = algF \/ (FailC . handleEffect . handle (Right ()) (either (handleReturn . Left) runFailC))
     where algF (Fail s) = FailC (handleReturn (Left s))
 
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -21,9 +21,9 @@ runFail = runFailC . interpret
 newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
-  handleReturn a = FailC (handleReturn (Right a))
-  handleEffect = algF \/ (FailC . handleEffect . handle (Right ()) (either (handleReturn . Left) runFailC))
-    where algF (Fail s) = FailC (handleReturn (Left s))
+  ret a = FailC (ret (Right a))
+  eff = algF \/ (FailC . eff . handle (Right ()) (either (ret . Left) runFailC))
+    where algF (Fail s) = FailC (ret (Left s))
 
 
 -- $setup

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -6,8 +6,8 @@ module Control.Effect.Fail
 , FailC(..)
 ) where
 
-import Control.Effect.Fail.Internal
 import Control.Effect.Carrier
+import Control.Effect.Fail.Internal
 import Control.Effect.Internal
 import Control.Effect.Sum
 import Control.Monad.Fail

--- a/src/Control/Effect/Fail/Internal.hs
+++ b/src/Control/Effect/Fail/Internal.hs
@@ -3,7 +3,7 @@ module Control.Effect.Fail.Internal
 ( Fail(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Data.Coerce
 
 newtype Fail m k = Fail String

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -7,7 +7,7 @@ module Control.Effect.Fresh
 , FreshC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -49,9 +49,9 @@ newtype FreshC m a = FreshC { runFreshC :: Int -> m (Int, a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Fresh :+: sig) (FreshC m) where
   ret a = FreshC (\ i -> ret (i, a))
-  eff op = FreshC (\ i -> (algF i \/ eff . handle (i, ()) (uncurry (flip runFreshC))) op)
-    where algF i (Fresh   k) = runFreshC (k i) (succ i)
-          algF i (Reset m k) = runFreshC m i >>= \ (_, a) -> runFreshC (k a) i
+  eff op = FreshC (\ i -> (alg i \/ eff . handle (i, ()) (uncurry (flip runFreshC))) op)
+    where alg i (Fresh   k) = runFreshC (k i) (succ i)
+          alg i (Reset m k) = runFreshC m i >>= \ (_, a) -> runFreshC (k a) i
 
 
 -- $setup

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -29,13 +29,13 @@ instance Effect Fresh where
 --
 --   prop> run (runFresh (replicateM n fresh)) == nub (run (runFresh (replicateM n fresh)))
 fresh :: (Member Fresh sig, Carrier sig m) => m Int
-fresh = send (Fresh handleReturn)
+fresh = send (Fresh ret)
 
 -- | Reset the fresh counter after running a computation.
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) == run (runFresh (replicateM n fresh))
 resetFresh :: (Member Fresh sig, Carrier sig m) => m a -> m a
-resetFresh m = send (Reset m handleReturn)
+resetFresh m = send (Reset m ret)
 
 
 -- | Run a 'Fresh' effect counting up from 0.
@@ -48,11 +48,11 @@ runFresh = fmap snd . flip runFreshC 0 . interpret
 newtype FreshC m a = FreshC { runFreshC :: Int -> m (Int, a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Fresh :+: sig) (FreshC m) where
-  handleReturn a = FreshC (\ i -> handleReturn (i, a))
-  handleEffect = algF \/ algOther
+  ret a = FreshC (\ i -> ret (i, a))
+  eff = algF \/ algOther
     where algF (Fresh   k) = FreshC (\ i -> runFreshC (k i) (succ i))
           algF (Reset m k) = FreshC (\ i -> runFreshC m i >>= \ (_, a) -> runFreshC (k a) i)
-          algOther op = FreshC (\ i -> handleEffect (handle (i, ()) (uncurry (flip runFreshC)) op))
+          algOther op = FreshC (\ i -> eff (handle (i, ()) (uncurry (flip runFreshC)) op))
 
 
 -- $setup

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -49,10 +49,10 @@ newtype FreshC m a = FreshC { runFreshC :: Int -> m (Int, a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Fresh :+: sig) (FreshC m) where
   handleReturn a = FreshC (\ i -> handleReturn (i, a))
-  alg = algF \/ algOther
+  handleEffect = algF \/ algOther
     where algF (Fresh   k) = FreshC (\ i -> runFreshC (k i) (succ i))
           algF (Reset m k) = FreshC (\ i -> runFreshC m i >>= \ (_, a) -> runFreshC (k a) i)
-          algOther op = FreshC (\ i -> alg (handle (i, ()) (uncurry (flip runFreshC)) op))
+          algOther op = FreshC (\ i -> handleEffect (handle (i, ()) (uncurry (flip runFreshC)) op))
 
 
 -- $setup

--- a/src/Control/Effect/Internal.hs
+++ b/src/Control/Effect/Internal.hs
@@ -75,7 +75,7 @@ instance (Member (Lift IO) sig, Carrier sig carrier) => MonadIO (Eff carrier) wh
 
 instance Carrier sig carrier => Carrier sig (Eff carrier) where
   handleReturn = pure
-  alg op = Eff (\ k -> alg (hmap (runEff handleReturn) (fmap' (runEff k) op)))
+  handleEffect op = Eff (\ k -> handleEffect (hmap (runEff handleReturn) (fmap' (runEff k) op)))
 
 
 -- $setup

--- a/src/Control/Effect/Internal.hs
+++ b/src/Control/Effect/Internal.hs
@@ -23,7 +23,7 @@ runEff = flip unEff
 {-# INLINE runEff #-}
 
 interpret :: Carrier sig carrier => Eff carrier a -> carrier a
-interpret = runEff handleReturn
+interpret = runEff ret
 {-# INLINE interpret #-}
 
 instance Functor (Eff carrier) where
@@ -74,8 +74,8 @@ instance (Member (Lift IO) sig, Carrier sig carrier) => MonadIO (Eff carrier) wh
 
 
 instance Carrier sig carrier => Carrier sig (Eff carrier) where
-  handleReturn = pure
-  handleEffect op = Eff (\ k -> handleEffect (hmap (runEff handleReturn) (fmap' (runEff k) op)))
+  ret = pure
+  eff op = Eff (\ k -> eff (hmap (runEff ret) (fmap' (runEff k) op)))
 
 
 -- $setup

--- a/src/Control/Effect/Internal.hs
+++ b/src/Control/Effect/Internal.hs
@@ -23,7 +23,7 @@ runEff = flip unEff
 {-# INLINE runEff #-}
 
 interpret :: Carrier sig carrier => Eff carrier a -> carrier a
-interpret = runEff gen
+interpret = runEff handleReturn
 {-# INLINE interpret #-}
 
 instance Functor (Eff carrier) where
@@ -74,8 +74,8 @@ instance (Member (Lift IO) sig, Carrier sig carrier) => MonadIO (Eff carrier) wh
 
 
 instance Carrier sig carrier => Carrier sig (Eff carrier) where
-  gen = pure
-  alg op = Eff (\ k -> alg (hmap (runEff gen) (fmap' (runEff k) op)))
+  handleReturn = pure
+  alg op = Eff (\ k -> alg (hmap (runEff handleReturn) (fmap' (runEff k) op)))
 
 
 -- $setup

--- a/src/Control/Effect/Internal.hs
+++ b/src/Control/Effect/Internal.hs
@@ -6,7 +6,7 @@ module Control.Effect.Internal
 ) where
 
 import Control.Applicative (Alternative(..))
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Fail.Internal
 import Control.Effect.Lift.Internal
 import Control.Effect.NonDet.Internal

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -5,7 +5,7 @@ module Control.Effect.Lift
 , LiftC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Lift.Internal
 

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -16,5 +16,5 @@ runM = runLiftC . interpret
 newtype LiftC m a = LiftC { runLiftC :: m a }
 
 instance Monad m => Carrier (Lift m) (LiftC m) where
-  handleReturn = LiftC . pure
-  handleEffect = LiftC . (>>= runLiftC) . unLift
+  ret = LiftC . pure
+  eff = LiftC . (>>= runLiftC) . unLift

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -17,4 +17,4 @@ newtype LiftC m a = LiftC { runLiftC :: m a }
 
 instance Monad m => Carrier (Lift m) (LiftC m) where
   handleReturn = LiftC . pure
-  alg = LiftC . (>>= runLiftC) . unLift
+  handleEffect = LiftC . (>>= runLiftC) . unLift

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -16,5 +16,5 @@ runM = runLiftC . interpret
 newtype LiftC m a = LiftC { runLiftC :: m a }
 
 instance Monad m => Carrier (Lift m) (LiftC m) where
-  gen = LiftC . pure
+  handleReturn = LiftC . pure
   alg = LiftC . (>>= runLiftC) . unLift

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -3,7 +3,7 @@ module Control.Effect.Lift.Internal
 ( Lift(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Data.Coerce
 
 newtype Lift sig m k = Lift { unLift :: sig k }

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -26,7 +26,7 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   handleReturn a = AltC (handleReturn (pure a))
-  alg = algND \/ (AltC . alg . handle (pure ()) (fmap join . traverse runAltC))
+  handleEffect = algND \/ (AltC . handleEffect . handle (pure ()) (fmap join . traverse runAltC))
     where algND Empty      = AltC (handleReturn empty)
           algND (Choose k) = AltC (liftA2 (<|>) (runAltC (k True)) (runAltC (k False)))
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -7,7 +7,7 @@ module Control.Effect.NonDet
 ) where
 
 import Control.Applicative (Alternative(..), liftA2)
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.NonDet.Internal
 import Control.Effect.Sum

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -25,9 +25,9 @@ runNonDet = runAltC . interpret
 newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
-  gen a = AltC (gen (pure a))
+  handleReturn a = AltC (handleReturn (pure a))
   alg = algND \/ (AltC . alg . handle (pure ()) (fmap join . traverse runAltC))
-    where algND Empty      = AltC (gen empty)
+    where algND Empty      = AltC (handleReturn empty)
           algND (Choose k) = AltC (liftA2 (<|>) (runAltC (k True)) (runAltC (k False)))
 
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -25,9 +25,9 @@ runNonDet = runAltC . interpret
 newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
-  handleReturn a = AltC (handleReturn (pure a))
-  handleEffect = algND \/ (AltC . handleEffect . handle (pure ()) (fmap join . traverse runAltC))
-    where algND Empty      = AltC (handleReturn empty)
+  ret a = AltC (ret (pure a))
+  eff = algND \/ (AltC . eff . handle (pure ()) (fmap join . traverse runAltC))
+    where algND Empty      = AltC (ret empty)
           algND (Choose k) = AltC (liftA2 (<|>) (runAltC (k True)) (runAltC (k False)))
 
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -26,9 +26,9 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   ret a = AltC (ret (pure a))
-  eff = AltC . (algND \/ eff . handle (pure ()) (fmap join . traverse runAltC))
-    where algND Empty      = ret empty
-          algND (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
+  eff = AltC . (alg \/ eff . handle (pure ()) (fmap join . traverse runAltC))
+    where alg Empty      = ret empty
+          alg (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
 
 
 -- $setup

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -26,9 +26,9 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   ret a = AltC (ret (pure a))
-  eff = algND \/ (AltC . eff . handle (pure ()) (fmap join . traverse runAltC))
-    where algND Empty      = AltC (ret empty)
-          algND (Choose k) = AltC (liftA2 (<|>) (runAltC (k True)) (runAltC (k False)))
+  eff = AltC . (algND \/ eff . handle (pure ()) (fmap join . traverse runAltC))
+    where algND Empty      = ret empty
+          algND (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
 
 
 -- $setup

--- a/src/Control/Effect/NonDet/Internal.hs
+++ b/src/Control/Effect/NonDet/Internal.hs
@@ -3,7 +3,7 @@ module Control.Effect.NonDet.Internal
 ( NonDet(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Data.Coerce
 
 data NonDet m k

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -8,7 +8,7 @@ module Control.Effect.Reader
 , ReaderC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -56,10 +56,9 @@ newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
   ret a = ReaderC (const (ret a))
-  eff = algR \/ algOther
-    where algR (Ask       k) = ReaderC (\ r -> runReaderC (k r) r)
-          algR (Local f m k) = ReaderC (\ r -> runReaderC m (f r) >>= flip runReaderC r . k)
-          algOther op = ReaderC (\ r -> eff (handlePure (flip runReaderC r) op))
+  eff op = ReaderC (\ r -> (algR r \/ eff . handlePure (flip runReaderC r)) op)
+    where algR r (Ask       k) = runReaderC (k r) r
+          algR r (Local f m k) = runReaderC m (f r) >>= flip runReaderC r . k
 
 
 -- $setup

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -56,10 +56,10 @@ newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
   handleReturn a = ReaderC (const (handleReturn a))
-  alg = algR \/ algOther
+  handleEffect = algR \/ algOther
     where algR (Ask       k) = ReaderC (\ r -> runReaderC (k r) r)
           algR (Local f m k) = ReaderC (\ r -> runReaderC m (f r) >>= flip runReaderC r . k)
-          algOther op = ReaderC (\ r -> alg (handlePure (flip runReaderC r) op))
+          algOther op = ReaderC (\ r -> handleEffect (handlePure (flip runReaderC r) op))
 
 
 -- $setup

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -56,9 +56,9 @@ newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
   ret a = ReaderC (const (ret a))
-  eff op = ReaderC (\ r -> (algR r \/ eff . handlePure (flip runReaderC r)) op)
-    where algR r (Ask       k) = runReaderC (k r) r
-          algR r (Local f m k) = runReaderC m (f r) >>= flip runReaderC r . k
+  eff op = ReaderC (\ r -> (alg r \/ eff . handlePure (flip runReaderC r)) op)
+    where alg r (Ask       k) = runReaderC (k r) r
+          alg r (Local f m k) = runReaderC m (f r) >>= flip runReaderC r . k
 
 
 -- $setup

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -30,7 +30,7 @@ instance Effect (Reader r) where
 --
 --   prop> run (runReader a ask) == a
 ask :: (Member (Reader r) sig, Carrier sig m) => m r
-ask = send (Ask gen)
+ask = send (Ask handleReturn)
 
 -- | Project a function out of the current environment value.
 --
@@ -43,7 +43,7 @@ asks f = fmap f ask
 --   prop> run (runReader a (local (applyFun f) ask)) == applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) == (a, applyFun f a, a)
 local :: (Member (Reader r) sig, Carrier sig m) => (r -> r) -> m a -> m a
-local f m = send (Local f m gen)
+local f m = send (Local f m handleReturn)
 
 
 -- | Run a 'Reader' effect with the passed environment value.
@@ -55,7 +55,7 @@ runReader r m = runReaderC (interpret m) r
 newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
-  gen a = ReaderC (const (gen a))
+  handleReturn a = ReaderC (const (handleReturn a))
   alg = algR \/ algOther
     where algR (Ask       k) = ReaderC (\ r -> runReaderC (k r) r)
           algR (Local f m k) = ReaderC (\ r -> runReaderC m (f r) >>= flip runReaderC r . k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -75,7 +75,7 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   handleReturn a = ResumableC (handleReturn (Right a))
-  alg = algE \/ (ResumableC . alg . handle (Right ()) (either (handleReturn . Left) runResumableC))
+  handleEffect = algE \/ (ResumableC . handleEffect . handle (Right ()) (either (handleReturn . Left) runResumableC))
     where algE (Resumable err _) = ResumableC (handleReturn (Left (SomeError err)))
 
 
@@ -100,9 +100,9 @@ runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   handleReturn a = ResumableWithC (const (handleReturn a))
-  alg = algR \/ algOther
+  handleEffect = algR \/ algOther
     where algR (Resumable err k) = ResumableWithC (\ f -> f err >>= runResumableWithC f . k)
-          algOther op = ResumableWithC (\ f -> alg (handlePure (runResumableWithC f) op))
+          algOther op = ResumableWithC (\ f -> handleEffect (handlePure (runResumableWithC f) op))
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -100,7 +100,7 @@ runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   ret a = ResumableWithC (const (ret a))
-  eff op = ResumableWithC (\ handler -> (algR handler \/ (eff . handlePure (runResumableWithC handler))) op)
+  eff op = ResumableWithC (\ handler -> (algR handler \/ eff . handlePure (runResumableWithC handler)) op)
     where algR :: Monad m => (forall x . err x -> m x) -> Resumable err (ResumableWithC err m) (ResumableWithC err m a) -> m a
           algR handler (Resumable err k) = handler err >>= runResumableWithC handler . k
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -75,8 +75,8 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = ResumableC . (algE \/ (eff . handle (Right ()) (either (ret . Left) runResumableC)))
-    where algE (Resumable err _) = ret (Left (SomeError err))
+  eff = ResumableC . (alg \/ (eff . handle (Right ()) (either (ret . Left) runResumableC)))
+    where alg (Resumable err _) = ret (Left (SomeError err))
 
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.
@@ -100,9 +100,9 @@ runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   ret a = ResumableWithC (const (ret a))
-  eff op = ResumableWithC (\ handler -> (algR handler \/ eff . handlePure (runResumableWithC handler)) op)
-    where algR :: Monad m => (forall x . err x -> m x) -> Resumable err (ResumableWithC err m) (ResumableWithC err m a) -> m a
-          algR handler (Resumable err k) = handler err >>= runResumableWithC handler . k
+  eff op = ResumableWithC (\ handler -> (alg handler \/ eff . handlePure (runResumableWithC handler)) op)
+    where alg :: Monad m => (forall x . err x -> m x) -> Resumable err (ResumableWithC err m) (ResumableWithC err m a) -> m a
+          alg handler (Resumable err k) = handler err >>= runResumableWithC handler . k
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -9,7 +9,7 @@ module Control.Effect.Resumable
 , ResumableWithC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
 import Data.Functor.Classes

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -75,7 +75,7 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = ResumableC . (alg \/ (eff . handle (Right ()) (either (ret . Left) runResumableC)))
+  eff = ResumableC . (alg \/ eff . handle (Right ()) (either (ret . Left) runResumableC))
     where alg (Resumable err _) = ret (Left (SomeError err))
 
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -75,8 +75,8 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = algE \/ (ResumableC . eff . handle (Right ()) (either (ret . Left) runResumableC))
-    where algE (Resumable err _) = ResumableC (ret (Left (SomeError err)))
+  eff = ResumableC . (algE \/ (eff . handle (Right ()) (either (ret . Left) runResumableC)))
+    where algE (Resumable err _) = ret (Left (SomeError err))
 
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -100,9 +100,9 @@ runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   ret a = ResumableWithC (const (ret a))
-  eff = algR \/ algOther
-    where algR (Resumable err k) = ResumableWithC (\ f -> f err >>= runResumableWithC f . k)
-          algOther op = ResumableWithC (\ f -> eff (handlePure (runResumableWithC f) op))
+  eff op = ResumableWithC (\ handler -> (algR handler \/ (eff . handlePure (runResumableWithC handler))) op)
+    where algR :: Monad m => (forall x . err x -> m x) -> Resumable err (ResumableWithC err m) (ResumableWithC err m a) -> m a
+          algR handler (Resumable err k) = handler err >>= runResumableWithC handler . k
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -99,7 +99,7 @@ runResumableWithC :: (forall x . err x -> m x) -> ResumableWithC err m a -> m a
 runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
-  handleReturn a = ResumableWithC (\ _ -> handleReturn a)
+  handleReturn a = ResumableWithC (const (handleReturn a))
   alg = algR \/ algOther
     where algR (Resumable err k) = ResumableWithC (\ f -> f err >>= runResumableWithC f . k)
           algOther op = ResumableWithC (\ f -> alg (handlePure (runResumableWithC f) op))

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -11,7 +11,7 @@ module Control.Effect.State
 , StateC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
 import Data.Coerce

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -81,9 +81,9 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   ret a = StateC (\ s -> ret (s, a))
-  eff op = StateC (\ s -> (algS s \/ eff . handle (s, ()) (uncurry (flip runStateC))) op)
-    where algS s (Get   k) = runStateC (k s) s
-          algS _ (Put s k) = runStateC  k    s
+  eff op = StateC (\ s -> (alg s \/ eff . handle (s, ()) (uncurry (flip runStateC))) op)
+    where alg s (Get   k) = runStateC (k s) s
+          alg _ (Put s k) = runStateC  k    s
 
 
 -- $setup

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -33,7 +33,7 @@ instance Effect (State s) where
 --
 --   prop> snd (run (runState a get)) == a
 get :: (Member (State s) sig, Carrier sig m) => m s
-get = send (Get gen)
+get = send (Get handleReturn)
 
 -- | Project a function out of the current state value.
 --
@@ -47,7 +47,7 @@ gets f = fmap f get
 --   prop> snd (run (runState a (get <* put b))) == a
 --   prop> snd (run (runState a (put b *> get))) == b
 put :: (Member (State s) sig, Carrier sig m) => s -> m ()
-put s = send (Put s (gen ()))
+put s = send (Put s (handleReturn ()))
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is strict in the new state; if you need laziness, use @get >>= put . f@.
@@ -80,7 +80,7 @@ execState s m = fmap fst (runStateC (interpret m) s)
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
-  gen a = StateC (\ s -> gen (s, a))
+  handleReturn a = StateC (\ s -> handleReturn (s, a))
   alg = algS \/ algOther
     where algS (Get   k) = StateC (\ s -> runStateC (k s) s)
           algS (Put s k) = StateC (\ _ -> runStateC  k    s)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -81,10 +81,9 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   ret a = StateC (\ s -> ret (s, a))
-  eff = algS \/ algOther
-    where algS (Get   k) = StateC (\ s -> runStateC (k s) s)
-          algS (Put s k) = StateC (\ _ -> runStateC  k    s)
-          algOther op = StateC (\ s -> eff (handle (s, ()) (uncurry (flip runStateC)) op))
+  eff op = StateC (\ s -> (algS s \/ eff . handle (s, ()) (uncurry (flip runStateC))) op)
+    where algS s (Get   k) = runStateC (k s) s
+          algS _ (Put s k) = runStateC  k    s
 
 
 -- $setup

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -81,10 +81,10 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   handleReturn a = StateC (\ s -> handleReturn (s, a))
-  alg = algS \/ algOther
+  handleEffect = algS \/ algOther
     where algS (Get   k) = StateC (\ s -> runStateC (k s) s)
           algS (Put s k) = StateC (\ _ -> runStateC  k    s)
-          algOther op = StateC (\ s -> alg (handle (s, ()) (uncurry (flip runStateC)) op))
+          algOther op = StateC (\ s -> handleEffect (handle (s, ()) (uncurry (flip runStateC)) op))
 
 
 -- $setup

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -58,4 +58,4 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a
-send = handleEffect . inj
+send = eff . inj

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -6,7 +6,7 @@ module Control.Effect.Sum
 , send
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 
 data (f :+: g) m k
   = L (f m k)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -58,4 +58,4 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a
-send = alg . inj
+send = handleEffect . inj

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -69,9 +69,8 @@ newtype ReturningC m a = ReturningC { runReturningC :: [String] -> m ([String], 
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (ReturningC m) where
   ret a = ReturningC (\ s -> ret (s, a))
-  eff = algT \/ algOther
-    where algT (Trace m k) = ReturningC (runReturningC k . (m :))
-          algOther op = ReturningC (\ s -> eff (handle (s, ()) (uncurry (flip runReturningC)) op))
+  eff op = ReturningC (\ s -> (algT s \/ eff . handle (s, ()) (uncurry (flip runReturningC))) op)
+    where algT s (Trace m k) = runReturningC k (m : s)
 
 
 -- $setup

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -10,7 +10,7 @@ module Control.Effect.Trace
 , ReturningC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
 import Control.Monad.IO.Class

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -41,8 +41,8 @@ newtype PrintingC m a = PrintingC { runPrintingC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (PrintingC m) where
   ret = PrintingC . ret
-  eff = algT \/ (PrintingC . eff . handlePure runPrintingC)
-    where algT (Trace s k) = PrintingC (liftIO (hPutStrLn stderr s) *> runPrintingC k)
+  eff = PrintingC . (algT \/ eff . handlePure runPrintingC)
+    where algT (Trace s k) = liftIO (hPutStrLn stderr s) *> runPrintingC k
 
 
 -- | Run a 'Trace' effect, ignoring all traces.

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -41,8 +41,8 @@ newtype PrintingC m a = PrintingC { runPrintingC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (PrintingC m) where
   ret = PrintingC . ret
-  eff = PrintingC . (algT \/ eff . handlePure runPrintingC)
-    where algT (Trace s k) = liftIO (hPutStrLn stderr s) *> runPrintingC k
+  eff = PrintingC . (alg \/ eff . handlePure runPrintingC)
+    where alg (Trace s k) = liftIO (hPutStrLn stderr s) *> runPrintingC k
 
 
 -- | Run a 'Trace' effect, ignoring all traces.
@@ -55,8 +55,8 @@ newtype IgnoringC m a = IgnoringC { runIgnoringC :: m a }
 
 instance Carrier sig m => Carrier (Trace :+: sig) (IgnoringC m) where
   ret = IgnoringC . ret
-  eff = algT \/ (IgnoringC . eff . handlePure runIgnoringC)
-    where algT (Trace _ k) = k
+  eff = alg \/ (IgnoringC . eff . handlePure runIgnoringC)
+    where alg (Trace _ k) = k
 
 
 -- | Run a 'Trace' effect, returning all traces as a list.
@@ -69,8 +69,8 @@ newtype ReturningC m a = ReturningC { runReturningC :: [String] -> m ([String], 
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (ReturningC m) where
   ret a = ReturningC (\ s -> ret (s, a))
-  eff op = ReturningC (\ s -> (algT s \/ eff . handle (s, ()) (uncurry (flip runReturningC))) op)
-    where algT s (Trace m k) = runReturningC k (m : s)
+  eff op = ReturningC (\ s -> (alg s \/ eff . handle (s, ()) (uncurry (flip runReturningC))) op)
+    where alg s (Trace m k) = runReturningC k (m : s)
 
 
 -- $setup

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -5,7 +5,7 @@ module Control.Effect.Void
 , VoidC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Internal
 
 data Void m k

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -25,5 +25,5 @@ run = runVoidC . interpret
 newtype VoidC a = VoidC { runVoidC :: a }
 
 instance Carrier Void VoidC where
-  gen = VoidC
+  handleReturn = VoidC
   alg v = case v of {}

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -26,4 +26,4 @@ newtype VoidC a = VoidC { runVoidC :: a }
 
 instance Carrier Void VoidC where
   handleReturn = VoidC
-  alg v = case v of {}
+  handleEffect v = case v of {}

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -25,5 +25,5 @@ run = runVoidC . interpret
 newtype VoidC a = VoidC { runVoidC :: a }
 
 instance Carrier Void VoidC where
-  handleReturn = VoidC
-  handleEffect v = case v of {}
+  ret = VoidC
+  eff v = case v of {}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -47,8 +47,8 @@ newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig, Functor m) => Carrier (Writer w :+: sig) (WriterC w m) where
   ret a = WriterC (ret (mempty, a))
-  eff = WriterC . (algW \/ eff . handle (mempty, ()) (uncurry runWriter'))
-    where algW (Tell w k) = first (w <>) <$> runWriterC k
+  eff = WriterC . (alg \/ eff . handle (mempty, ()) (uncurry runWriter'))
+    where alg (Tell w k) = first (w <>) <$> runWriterC k
           runWriter' w = fmap (first (w <>)) . runWriterC
 
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -47,7 +47,7 @@ newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig, Functor m) => Carrier (Writer w :+: sig) (WriterC w m) where
   handleReturn a = WriterC (handleReturn (mempty, a))
-  alg = algW \/ (WriterC . alg . handle (mempty, ()) (uncurry runWriter'))
+  handleEffect = algW \/ (WriterC . handleEffect . handle (mempty, ()) (uncurry runWriter'))
     where algW (Tell w k) = WriterC (first (w <>) <$> runWriterC k)
           runWriter' w = fmap (first (w <>)) . runWriterC
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -27,7 +27,7 @@ instance Effect (Writer w) where
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) == foldMap Sum ws
 tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
-tell w = send (Tell w (handleReturn ()))
+tell w = send (Tell w (ret ()))
 
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
@@ -46,8 +46,8 @@ execWriter m = fmap fst (runWriterC (interpret m))
 newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig, Functor m) => Carrier (Writer w :+: sig) (WriterC w m) where
-  handleReturn a = WriterC (handleReturn (mempty, a))
-  handleEffect = algW \/ (WriterC . handleEffect . handle (mempty, ()) (uncurry runWriter'))
+  ret a = WriterC (ret (mempty, a))
+  eff = algW \/ (WriterC . eff . handle (mempty, ()) (uncurry runWriter'))
     where algW (Tell w k) = WriterC (first (w <>) <$> runWriterC k)
           runWriter' w = fmap (first (w <>)) . runWriterC
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -47,8 +47,8 @@ newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig, Functor m) => Carrier (Writer w :+: sig) (WriterC w m) where
   ret a = WriterC (ret (mempty, a))
-  eff = algW \/ (WriterC . eff . handle (mempty, ()) (uncurry runWriter'))
-    where algW (Tell w k) = WriterC (first (w <>) <$> runWriterC k)
+  eff = WriterC . (algW \/ eff . handle (mempty, ()) (uncurry runWriter'))
+    where algW (Tell w k) = first (w <>) <$> runWriterC k
           runWriter' w = fmap (first (w <>)) . runWriterC
 
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -7,7 +7,7 @@ module Control.Effect.Writer
 , WriterC(..)
 ) where
 
-import Control.Effect.Handler
+import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
 import Data.Bifunctor (first)

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -44,9 +44,9 @@ newtype ReinterpretReaderC r m a = ReinterpretReaderC { runReinterpretReaderC ::
 
 instance (Carrier (State r :+: sig) m, Effect sig, Monad m) => Carrier (Reader r :+: sig) (ReinterpretReaderC r m) where
   ret = ReinterpretReaderC . ret
-  eff = ReinterpretReaderC . (algR \/ eff . R . handlePure runReinterpretReaderC)
-    where algR (Ask       k) = get >>= runReinterpretReaderC . k
-          algR (Local f m k) = do
+  eff = ReinterpretReaderC . (alg \/ eff . R . handlePure runReinterpretReaderC)
+    where alg (Ask       k) = get >>= runReinterpretReaderC . k
+          alg (Local f m k) = do
             a <- get
             put (f a)
             v <- runReinterpretReaderC m

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -44,9 +44,9 @@ newtype ReinterpretReaderC r m a = ReinterpretReaderC { runReinterpretReaderC ::
 
 instance (Carrier (State r :+: sig) m, Effect sig, Monad m) => Carrier (Reader r :+: sig) (ReinterpretReaderC r m) where
   ret = ReinterpretReaderC . ret
-  eff = algR \/ (ReinterpretReaderC . eff . R . handlePure runReinterpretReaderC)
-    where algR (Ask       k) = ReinterpretReaderC (get >>= runReinterpretReaderC . k)
-          algR (Local f m k) = ReinterpretReaderC $ do
+  eff = ReinterpretReaderC . (algR \/ eff . R . handlePure runReinterpretReaderC)
+    where algR (Ask       k) = get >>= runReinterpretReaderC . k
+          algR (Local f m k) = do
             a <- get
             put (f a)
             v <- runReinterpretReaderC m

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -28,8 +28,8 @@ newtype HasEnv env carrier a = HasEnv { runHasEnv :: Eff carrier a }
   deriving (Applicative, Functor, Monad)
 
 instance Carrier sig carrier => Carrier sig (HasEnv env carrier) where
-  handleReturn = pure
-  handleEffect op = HasEnv (handleEffect (handlePure runHasEnv op))
+  ret = pure
+  eff op = HasEnv (eff (handlePure runHasEnv op))
 
 
 reinterpretation :: Spec
@@ -43,8 +43,8 @@ reinterpretReader = runReinterpretReaderC . interpret
 newtype ReinterpretReaderC r m a = ReinterpretReaderC { runReinterpretReaderC :: m a }
 
 instance (Carrier (State r :+: sig) m, Effect sig, Monad m) => Carrier (Reader r :+: sig) (ReinterpretReaderC r m) where
-  handleReturn = ReinterpretReaderC . handleReturn
-  handleEffect = algR \/ (ReinterpretReaderC . handleEffect . R . handlePure runReinterpretReaderC)
+  ret = ReinterpretReaderC . ret
+  eff = algR \/ (ReinterpretReaderC . eff . R . handlePure runReinterpretReaderC)
     where algR (Ask       k) = ReinterpretReaderC (get >>= runReinterpretReaderC . k)
           algR (Local f m k) = ReinterpretReaderC $ do
             a <- get
@@ -69,7 +69,7 @@ interposeFail = runInterposeC . interpret
 newtype InterposeC m a = InterposeC { runInterposeC :: m a }
 
 instance (Member Fail sig, Carrier sig m) => Carrier sig (InterposeC m) where
-  handleReturn = InterposeC . handleReturn
-  handleEffect op
+  ret = InterposeC . ret
+  eff op
     | Just (Fail s) <- prj op = InterposeC (send (Fail ("hello, " ++ s)))
-    | otherwise               = InterposeC (handleEffect (handlePure runInterposeC op))
+    | otherwise               = InterposeC (eff (handlePure runInterposeC op))


### PR DESCRIPTION
This PR:

- [x] Renames `Control.Effect.Handler` to `Control.Effect.Carrier`.
- [x] Renames `gen` to `ret`.
- [x] Renames `alg` to `eff`.
- [x] Factors the `newtype` constructors out of the algebras.
- [x] Renames all the algebra helpers to `alg`, for consistency’s sake.
- [x] Documents `ret` and `eff` (a little).