### PR TITLE
Less poly-kinded

### DIFF
--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fail
 ( Fail(..)
 , MonadFail(..)

--- a/src/Control/Effect/Fail/Internal.hs
+++ b/src/Control/Effect/Fail/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, PolyKinds #-}
+{-# LANGUAGE DeriveFunctor, KindSignatures #-}
 module Control.Effect.Fail.Internal
 ( Fail(..)
 ) where
@@ -6,7 +6,7 @@ module Control.Effect.Fail.Internal
 import Control.Effect.Carrier
 import Data.Coerce
 
-newtype Fail m k = Fail String
+newtype Fail (m :: * -> *) k = Fail String
   deriving (Functor)
 
 instance HFunctor Fail where

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fresh
 ( Fresh(..)
 , fresh

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, PolyKinds #-}
+{-# LANGUAGE DeriveFunctor, KindSignatures #-}
 module Control.Effect.Lift.Internal
 ( Lift(..)
 ) where
@@ -6,7 +6,7 @@ module Control.Effect.Lift.Internal
 import Control.Effect.Carrier
 import Data.Coerce
 
-newtype Lift sig m k = Lift { unLift :: sig k }
+newtype Lift sig (m :: * -> *) k = Lift { unLift :: sig k }
   deriving (Functor)
 
 instance Functor sig => HFunctor (Lift sig) where

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
 ( NonDet(..)
 , Alternative(..)

--- a/src/Control/Effect/NonDet/Internal.hs
+++ b/src/Control/Effect/NonDet/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, PolyKinds #-}
+{-# LANGUAGE DeriveFunctor, KindSignatures #-}
 module Control.Effect.NonDet.Internal
 ( NonDet(..)
 ) where
@@ -6,7 +6,7 @@ module Control.Effect.NonDet.Internal
 import Control.Effect.Carrier
 import Data.Coerce
 
-data NonDet m k
+data NonDet (m :: * -> *) k
   = Empty
   | Choose (Bool -> k)
   deriving (Functor)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Resumable
 ( Resumable(..)
 , throwResumable
@@ -17,7 +17,7 @@ import Data.Coerce
 import Data.Functor.Classes
 
 -- | Errors which can be resumed with values of some existentially-quantified type.
-data Resumable err m k
+data Resumable err (m :: * -> *) k
   = forall a . Resumable (err a) (a -> k)
 
 deriving instance Functor (Resumable err m)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -13,6 +13,7 @@ import Control.DeepSeq
 import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
+import Data.Coerce
 import Data.Functor.Classes
 
 -- | Errors which can be resumed with values of some existentially-quantified type.
@@ -22,7 +23,8 @@ data Resumable err m k
 deriving instance Functor (Resumable err m)
 
 instance HFunctor (Resumable err) where
-  hmap _ (Resumable err k) = Resumable err k
+  hmap _ = coerce
+  {-# INLINE hmap #-}
 
 instance Effect (Resumable err) where
   handle state handler (Resumable err k) = Resumable err (handler . (<$ state) . k)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State
 ( State(..)
 , get
@@ -16,7 +16,7 @@ import Control.Effect.Sum
 import Control.Effect.Internal
 import Data.Coerce
 
-data State s m k
+data State s (m :: * -> *) k
   = Get (s -> k)
   | Put s k
   deriving (Functor)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , (\/)
@@ -8,7 +8,7 @@ module Control.Effect.Sum
 
 import Control.Effect.Carrier
 
-data (f :+: g) m k
+data (f :+: g) (m :: * -> *) k
   = L (f m k)
   | R (g m k)
   deriving (Eq, Functor, Ord, Show)
@@ -37,7 +37,7 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
 infixr 4 \/
 
 
-class Member (sub :: (k -> *) -> (k -> *)) sup where
+class Member (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a
   prj :: sup m a -> Maybe (sub m a)
 

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Trace
 ( Trace(..)
 , trace
@@ -18,7 +18,7 @@ import Data.Bifunctor (first)
 import Data.Coerce
 import System.IO
 
-data Trace m k = Trace String k
+data Trace (m :: * -> *) k = Trace String k
   deriving (Functor)
 
 instance HFunctor Trace where

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, EmptyCase, MultiParamTypeClasses, PolyKinds #-}
+{-# LANGUAGE DeriveFunctor, EmptyCase, KindSignatures, MultiParamTypeClasses #-}
 module Control.Effect.Void
 ( Void
 , run
@@ -8,7 +8,7 @@ module Control.Effect.Void
 import Control.Effect.Carrier
 import Control.Effect.Internal
 
-data Void m k
+data Void (m :: * -> *) k
   deriving (Functor)
 
 instance HFunctor Void where

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Writer
 ( Writer(..)
 , tell
@@ -13,7 +13,7 @@ import Control.Effect.Internal
 import Data.Bifunctor (first)
 import Data.Coerce
 
-data Writer w m k = Tell w k
+data Writer w (m :: * -> *) k = Tell w k
   deriving (Functor)
 
 instance HFunctor (Writer w) where


### PR DESCRIPTION
`PolyKinds` is less foolproof than `KindSignatures`: `Carrier` instances for poly-kinded first-order effects defined in other files end up requiring `PolyKinds` too, but if the effects are defined with kind signatures on then the file defining the `Carrier` instances doesn’t have to.

This + the docs in #22 should be a complete resolution to #13.