### PR TITLE
Batteries-included handlers

### DIFF
--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -44,7 +44,7 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Teletype :+: sig) (TeletypeIOC m) where
   ret = TeletypeIOC . ret
-  eff = TeletypeIOC . (alg \/ eff . handlePure runTeletypeIOC)
+  eff = TeletypeIOC . (alg \/ eff . handleCoercible)
     where alg (Read    k) = liftIO getLine >>= runTeletypeIOC . k
           alg (Write s k) = liftIO (putStrLn s) >> runTeletypeIOC k
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -51,18 +51,22 @@ handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g
 handlePure handler = hmap handler . fmap' handler
 {-# INLINE handlePure #-}
 
+-- | Thread a @Reader@-like carrier through an 'HFunctor'.
 handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)
 handleReader r run = handlePure (flip run r)
 {-# INLINE handleReader #-}
 
+-- | Thread a @State@-like carrier through an 'Effect'.
 handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f a) -> sig g (g (s, a))
 handleState s run = handle (s, ()) (uncurry (flip run))
 {-# INLINE handleState #-}
 
+-- | Thread a carrier producing 'Either's through an 'Effect'.
 handleEither :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
 handleEither run = handle (Right ()) (either (ret . Left) run)
 {-# INLINE handleEither #-}
 
+-- | Thread a carrier producing values in a 'Traversable' 'Monad' (e.g. '[]') through an 'Effect'.
 handleTraversable :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
 handleTraversable run = handle (pure ()) (fmap join . traverse run)
 {-# INLINE handleTraversable #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -7,7 +7,7 @@ module Control.Effect.Carrier
 , handleReader
 , handleState
 , handleEither
-, handleTraversableMonad
+, handleTraversable
 ) where
 
 import Control.Monad (join)
@@ -63,6 +63,6 @@ handleEither :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)
 handleEither run = handle (Right ()) (either (ret . Left) run)
 {-# INLINE handleEither #-}
 
-handleTraversableMonad :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
-handleTraversableMonad run = handle (pure ()) (fmap join . traverse run)
-{-# INLINE handleTraversableMonad #-}
+handleTraversable :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
+handleTraversable run = handle (pure ()) (fmap join . traverse run)
+{-# INLINE handleTraversable #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -6,7 +6,7 @@ module Control.Effect.Carrier
 , handlePure
 , handleReader
 , handleState
-, handleError
+, handleEither
 , handleTraversableMonad
 ) where
 
@@ -59,9 +59,9 @@ handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f 
 handleState s run = handle (s, ()) (uncurry (flip run))
 {-# INLINE handleState #-}
 
-handleError :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
-handleError run = handle (Right ()) (either (ret . Left) run)
-{-# INLINE handleError #-}
+handleEither :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
+handleEither run = handle (Right ()) (either (ret . Left) run)
+{-# INLINE handleEither #-}
 
 handleTraversableMonad :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
 handleTraversableMonad run = handle (pure ()) (fmap join . traverse run)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -53,7 +53,9 @@ handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g
 handlePure handler = hmap handler . fmap' handler
 {-# INLINE handlePure #-}
 
--- | Thread a @Reader@-like carrier through an 'HFunctor'.
+-- | Thread a 'Coercible' carrier through an 'HFunctor'.
+--
+--   This is applicable whenever @f@ is 'Coercible' to @g@, e.g. simple @newtype@s.
 handleCoercible :: (HFunctor sig, Coercible f g) => sig f (f a) -> sig g (g a)
 handleCoercible = handlePure coerce
 {-# INLINE handleCoercible #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -7,7 +7,10 @@ module Control.Effect.Carrier
 , handleReader
 , handleState
 , handleError
+, handleTraversableMonad
 ) where
+
+import Control.Monad (join)
 
 class HFunctor h where
   -- | Functor map. This is required to be 'fmap'.
@@ -59,3 +62,7 @@ handleState s run = handle (s, ()) (uncurry (flip run))
 handleError :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
 handleError run = handle (Right ()) (either (ret . Left) run)
 {-# INLINE handleError #-}
+
+handleTraversableMonad :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
+handleTraversableMonad run = handle (pure ()) (fmap join . traverse run)
+{-# INLINE handleTraversableMonad #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -5,6 +5,7 @@ module Control.Effect.Carrier
 , Carrier(..)
 , handlePure
 , handleReader
+, handleState
 ) where
 
 class HFunctor h where
@@ -49,3 +50,7 @@ handlePure handler = hmap handler . fmap' handler
 handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)
 handleReader r run = handlePure (flip run r)
 {-# INLINE handleReader #-}
+
+handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f a) -> sig g (g (s, a))
+handleState s run = handle (s, ()) (uncurry (flip run))
+{-# INLINE handleState #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -4,6 +4,7 @@ module Control.Effect.Carrier
 , Effect(..)
 , Carrier(..)
 , handlePure
+, handleCoercible
 , handleReader
 , handleState
 , handleEither
@@ -11,6 +12,7 @@ module Control.Effect.Carrier
 ) where
 
 import Control.Monad (join)
+import Data.Coerce
 
 class HFunctor h where
   -- | Functor map. This is required to be 'fmap'.
@@ -50,6 +52,11 @@ class HFunctor sig => Carrier sig h | h -> sig where
 handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g a)
 handlePure handler = hmap handler . fmap' handler
 {-# INLINE handlePure #-}
+
+-- | Thread a @Reader@-like carrier through an 'HFunctor'.
+handleCoercible :: (HFunctor sig, Coercible f g) => sig f (f a) -> sig g (g a)
+handleCoercible = handlePure coerce
+{-# INLINE handleCoercible #-}
 
 -- | Thread a @Reader@-like carrier through an 'HFunctor'.
 handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -6,6 +6,7 @@ module Control.Effect.Carrier
 , handlePure
 , handleReader
 , handleState
+, handleError
 ) where
 
 class HFunctor h where
@@ -54,3 +55,7 @@ handleReader r run = handlePure (flip run r)
 handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f a) -> sig g (g (s, a))
 handleState s run = handle (s, ()) (uncurry (flip run))
 {-# INLINE handleState #-}
+
+handleError :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
+handleError run = handle (Right ()) (either (ret . Left) run)
+{-# INLINE handleError #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -4,6 +4,7 @@ module Control.Effect.Carrier
 , Effect(..)
 , Carrier(..)
 , handlePure
+, handleReader
 ) where
 
 class HFunctor h where
@@ -44,3 +45,7 @@ class HFunctor sig => Carrier sig h | h -> sig where
 handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g a)
 handlePure handler = hmap handler . fmap' handler
 {-# INLINE handlePure #-}
+
+handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)
+handleReader r run = handlePure (flip run r)
+{-# INLINE handleReader #-}

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -53,7 +53,7 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
   ret a = ErrorC (pure (Right a))
-  eff = ErrorC . (alg \/ eff . handle (Right ()) (either (pure . Left) runErrorC))
+  eff = ErrorC . (alg \/ eff . handleError runErrorC)
     where alg (Throw e)     = pure (Left e)
           alg (Catch m h k) = runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k)
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -53,7 +53,7 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Error e :+: sig) (ErrorC e m) where
   ret a = ErrorC (pure (Right a))
-  eff = ErrorC . (alg \/ eff . handleError runErrorC)
+  eff = ErrorC . (alg \/ eff . handleEither runErrorC)
     where alg (Throw e)     = pure (Left e)
           alg (Catch m h k) = runErrorC m >>= either (either (pure . Left) (runErrorC . k) <=< runErrorC . h) (runErrorC . k)
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,7 +22,7 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   ret a = FailC (ret (Right a))
-  eff = FailC . (alg \/ eff . handleError runFailC)
+  eff = FailC . (alg \/ eff . handleEither runFailC)
     where alg (Fail s) = ret (Left s)
 
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,7 +22,7 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   ret a = FailC (ret (Right a))
-  eff = FailC . (alg \/ eff . handle (Right ()) (either (ret . Left) runFailC))
+  eff = FailC . (alg \/ eff . handleError runFailC)
     where alg (Fail s) = ret (Left s)
 
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -49,7 +49,7 @@ newtype FreshC m a = FreshC { runFreshC :: Int -> m (Int, a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Fresh :+: sig) (FreshC m) where
   ret a = FreshC (\ i -> ret (i, a))
-  eff op = FreshC (\ i -> (alg i \/ eff . handle (i, ()) (uncurry (flip runFreshC))) op)
+  eff op = FreshC (\ i -> (alg i \/ eff . handleState i runFreshC) op)
     where alg i (Fresh   k) = runFreshC (k i) (succ i)
           alg i (Reset m k) = runFreshC m i >>= \ (_, a) -> runFreshC (k a) i
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -11,7 +11,6 @@ import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.NonDet.Internal
 import Control.Effect.Sum
-import Control.Monad (join)
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
 --
@@ -26,7 +25,7 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   ret a = AltC (ret (pure a))
-  eff = AltC . (alg \/ eff . handle (pure ()) (fmap join . traverse runAltC))
+  eff = AltC . (alg \/ eff . handleTraversableMonad runAltC)
     where alg Empty      = ret empty
           alg (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -25,7 +25,7 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   ret a = AltC (ret (pure a))
-  eff = AltC . (alg \/ eff . handleTraversableMonad runAltC)
+  eff = AltC . (alg \/ eff . handleTraversable runAltC)
     where alg Empty      = ret empty
           alg (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -56,7 +56,7 @@ newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
   ret a = ReaderC (const (ret a))
-  eff op = ReaderC (\ r -> (alg r \/ eff . handlePure (flip runReaderC r)) op)
+  eff op = ReaderC (\ r -> (alg r \/ eff . handleReader r runReaderC) op)
     where alg r (Ask       k) = runReaderC (k r) r
           alg r (Local f m k) = runReaderC m (f r) >>= flip runReaderC r . k
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -85,7 +85,7 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = ResumableC . (alg \/ eff . handle (Right ()) (either (ret . Left) runResumableC))
+  eff = ResumableC . (alg \/ eff . handleError runResumableC)
     where alg (Resumable err _) = ret (Left (SomeError err))
 
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -85,7 +85,7 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = ResumableC . (alg \/ eff . handleError runResumableC)
+  eff = ResumableC . (alg \/ eff . handleEither runResumableC)
     where alg (Resumable err _) = ret (Left (SomeError err))
 
 

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -81,7 +81,7 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   ret a = StateC (\ s -> ret (s, a))
-  eff op = StateC (\ s -> (alg s \/ eff . handle (s, ()) (uncurry (flip runStateC))) op)
+  eff op = StateC (\ s -> (alg s \/ eff . handleState s runStateC) op)
     where alg s (Get   k) = runStateC (k s) s
           alg _ (Put s k) = runStateC  k    s
 

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -69,7 +69,7 @@ newtype TraceByReturningC m a = TraceByReturningC { runTraceByReturningC :: [Str
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (TraceByReturningC m) where
   ret a = TraceByReturningC (\ s -> ret (s, a))
-  eff op = TraceByReturningC (\ s -> (alg s \/ eff . handle (s, ()) (uncurry (flip runTraceByReturningC))) op)
+  eff op = TraceByReturningC (\ s -> (alg s \/ eff . handleState s runTraceByReturningC) op)
     where alg s (Trace m k) = runTraceByReturningC k (m : s)
 
 

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -34,7 +34,7 @@ newtype HasEnv env carrier a = HasEnv { runHasEnv :: Eff carrier a }
 
 instance Carrier sig carrier => Carrier sig (HasEnv env carrier) where
   ret = pure
-  eff op = HasEnv (eff (handlePure runHasEnv op))
+  eff op = HasEnv (eff (handleCoercible op))
 
 
 reinterpretation :: Spec

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -77,4 +77,4 @@ instance (Member Fail sig, Carrier sig m) => Carrier sig (InterposeC m) where
   ret = InterposeC . ret
   eff op
     | Just (Fail s) <- prj op = InterposeC (send (Fail ("hello, " ++ s)))
-    | otherwise               = InterposeC (eff (handlePure runInterposeC op))
+    | otherwise               = InterposeC (eff (handleCoercible op))

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -49,7 +49,7 @@ newtype ReinterpretReaderC r m a = ReinterpretReaderC { runReinterpretReaderC ::
 
 instance (Carrier (State r :+: sig) m, Effect sig, Monad m) => Carrier (Reader r :+: sig) (ReinterpretReaderC r m) where
   ret = ReinterpretReaderC . ret
-  eff = ReinterpretReaderC . (alg \/ eff . R . handlePure runReinterpretReaderC)
+  eff = ReinterpretReaderC . (alg \/ eff . R . handleCoercible)
     where alg (Ask       k) = get >>= runReinterpretReaderC . k
           alg (Local f m k) = do
             a <- get


### PR DESCRIPTION
This PR:

- [x] Defines batteries-included liftings of carriers through signatures for a variety of common carrier styles, including `State`-like carriers (like `StateC` or `FreshC`), `Either`-producing carriers (like `ErrorC`, `ResumableC`, or `FailC`), and others.
- [x] Contrary to discussion in #23 and #29, these do not include the reduction of the signature to the underlying carrier (i.e. they do not call `eff`). This was chosen to avoid needing to define separate families of handlers for interpreters, reinterpreters to single new effects, reinterpreters to multiple new effects, etc.
- [x] Fixes #29.