### PR TITLE
Handler ergonomics

### DIFF
--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 module Teletype where
 
@@ -51,9 +51,9 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Teletype :+: sig) (TeletypeIOC m) where
   ret = pure
-  eff = alg \/ TeletypeIOC . eff . handleCoercible
-    where alg (Read    k) = liftIO getLine      >>= k
-          alg (Write s k) = liftIO (putStrLn s) >>  k
+  eff = handleSum (TeletypeIOC . eff . handleCoercible) (\case
+    Read    k -> liftIO getLine      >>= k
+    Write s k -> liftIO (putStrLn s) >>  k)
 
 
 runTeletypeRet :: (Carrier sig m, Effect sig, Monad m) => [String] -> Eff (TeletypeRetC m) a -> m (([String], [String]), a)

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -22,8 +22,7 @@ newtype FailC m a = FailC { runFailC :: m (Either String a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
   ret a = FailC (ret (Right a))
-  eff = FailC . (alg \/ eff . handleEither runFailC)
-    where alg (Fail s) = ret (Left s)
+  eff = FailC . handleSum (eff . handleEither runFailC) (\ (Fail s) -> ret (Left s))
 
 
 -- $setup

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fresh
 ( Fresh(..)
 , fresh
@@ -49,9 +49,9 @@ newtype FreshC m a = FreshC { runFreshC :: Int -> m (Int, a) }
 
 instance (Carrier sig m, Effect sig, Monad m) => Carrier (Fresh :+: sig) (FreshC m) where
   ret a = FreshC (\ i -> ret (i, a))
-  eff op = FreshC (\ i -> (alg i \/ eff . handleState i runFreshC) op)
-    where alg i (Fresh   k) = runFreshC (k i) (succ i)
-          alg i (Reset m k) = runFreshC m i >>= \ (_, a) -> runFreshC (k a) i
+  eff op = FreshC (\ i -> handleSum (eff . handleState i runFreshC) (\case
+    Fresh   k -> runFreshC (k i) (succ i)
+    Reset m k -> runFreshC m i >>= flip runFreshC i . k . snd) op)
 
 
 -- $setup

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
 ( NonDet(..)
 , Alternative(..)
@@ -25,9 +25,9 @@ newtype AltC f m a = AltC { runAltC :: m (f a) }
 
 instance (Alternative f, Monad f, Traversable f, Carrier sig m, Effect sig, Applicative m) => Carrier (NonDet :+: sig) (AltC f m) where
   ret a = AltC (ret (pure a))
-  eff = AltC . (alg \/ eff . handleTraversable runAltC)
-    where alg Empty      = ret empty
-          alg (Choose k) = liftA2 (<|>) (runAltC (k True)) (runAltC (k False))
+  eff = AltC . handleSum (eff . handleTraversable runAltC) (\case
+    Empty    -> ret empty
+    Choose k -> liftA2 (<|>) (runAltC (k True)) (runAltC (k False)))
 
 
 -- $setup

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Reader
 ( Reader(..)
 , ask
@@ -56,9 +56,9 @@ newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
 
 instance (Carrier sig m, Monad m) => Carrier (Reader r :+: sig) (ReaderC r m) where
   ret a = ReaderC (const (ret a))
-  eff op = ReaderC (\ r -> (alg r \/ eff . handleReader r runReaderC) op)
-    where alg r (Ask       k) = runReaderC (k r) r
-          alg r (Local f m k) = runReaderC m (f r) >>= flip runReaderC r . k
+  eff op = ReaderC (\ r -> handleSum (eff . handleReader r runReaderC) (\case
+    Ask       k -> runReaderC (k r) r
+    Local f m k -> runReaderC m (f r) >>= flip runReaderC r . k) op)
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -111,9 +111,9 @@ runResumableWithC f (ResumableWithC m) = m f
 
 instance (Carrier sig m, Monad m) => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   ret a = ResumableWithC (const (ret a))
-  eff op = ResumableWithC (\ handler -> (alg handler \/ eff . handlePure (runResumableWithC handler)) op)
-    where alg :: Monad m => (forall x . err x -> m x) -> Resumable err (ResumableWithC err m) (ResumableWithC err m a) -> m a
-          alg handler (Resumable err k) = handler err >>= runResumableWithC handler . k
+  eff op = ResumableWithC (\ handler -> handleSum
+    (eff . handlePure (runResumableWithC handler))
+    (\ (Resumable err k) -> handler err >>= runResumableWithC handler . k) op)
 
 
 -- $setup

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -85,8 +85,9 @@ newtype ResumableC err m a = ResumableC { runResumableC :: m (Either (SomeError 
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   ret a = ResumableC (ret (Right a))
-  eff = ResumableC . (alg \/ eff . handleEither runResumableC)
-    where alg (Resumable err _) = ret (Left (SomeError err))
+  eff = ResumableC . handleSum
+    (eff . handleEither runResumableC)
+    (\ (Resumable err _) -> ret (Left (SomeError err)))
 
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State
 ( State(..)
 , get
@@ -81,9 +81,9 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   ret a = StateC (\ s -> ret (s, a))
-  eff op = StateC (\ s -> (alg s \/ eff . handleState s runStateC) op)
-    where alg s (Get   k) = runStateC (k s) s
-          alg _ (Put s k) = runStateC  k    s
+  eff op = StateC (\ s -> handleSum (eff . handleState s runStateC) (\case
+    Get   k -> runStateC (k s) s
+    Put s k -> runStateC  k    s) op)
 
 
 -- $setup

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -2,6 +2,7 @@
 module Control.Effect.Sum
 ( (:+:)(..)
 , (\/)
+, handleSum
 , Member(..)
 , send
 ) where
@@ -35,6 +36,12 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
 (_    \/ alg2) (R op) = alg2 op
 
 infixr 4 \/
+
+handleSum :: (          sig2  m a -> b)
+          -> ( sig1           m a -> b)
+          -> ((sig1 :+: sig2) m a -> b)
+handleSum alg1 _    (R op) = alg1 op
+handleSum _    alg2 (L op) = alg2 op
 
 
 class Member (sub :: (* -> *) -> (* -> *)) sup where

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -28,6 +28,8 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
 
 
 -- | Lift algebras for either side of a sum into a single algebra on sums.
+--
+--   Note that the order of the functions is the opposite of members of the sum. This is more convenient for defining effect handlers as lambdas (especially using @-XLambdaCase@) on the right, enabling better error messaging when using typed holes than would be the case with a binding in a where clause.
 handleSum :: (          sig2  m a -> b)
           -> ( sig1           m a -> b)
           -> ((sig1 :+: sig2) m a -> b)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
-, (\/)
 , handleSum
 , Member(..)
 , send
@@ -29,14 +28,6 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
 
 
 -- | Lift algebras for either side of a sum into a single algebra on sums.
-(\/) :: ( sig1           m a -> b)
-     -> (          sig2  m a -> b)
-     -> ((sig1 :+: sig2) m a -> b)
-(alg1 \/ _   ) (L op) = alg1 op
-(_    \/ alg2) (R op) = alg2 op
-
-infixr 4 \/
-
 handleSum :: (          sig2  m a -> b)
           -> ( sig1           m a -> b)
           -> ((sig1 :+: sig2) m a -> b)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -18,7 +18,10 @@ import Data.Bifunctor (first)
 import Data.Coerce
 import System.IO
 
-data Trace (m :: * -> *) k = Trace String k
+data Trace (m :: * -> *) k = Trace
+  { traceMessage :: String
+  , traceCont    :: k
+  }
   deriving (Functor)
 
 instance HFunctor Trace where

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -59,7 +59,7 @@ newtype TraceByIgnoringC m a = TraceByIgnoringC { runTraceByIgnoringC :: m a }
 
 instance Carrier sig m => Carrier (Trace :+: sig) (TraceByIgnoringC m) where
   ret = TraceByIgnoringC . ret
-  eff = traceCont \/ TraceByIgnoringC . eff . handlePure runTraceByIgnoringC
+  eff = handleSum (TraceByIgnoringC . eff . handlePure runTraceByIgnoringC) traceCont
 
 
 -- | Run a 'Trace' effect, returning all traces as a list.

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -72,8 +72,9 @@ newtype TraceByReturningC m a = TraceByReturningC { runTraceByReturningC :: [Str
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (TraceByReturningC m) where
   ret a = TraceByReturningC (\ s -> ret (s, a))
-  eff op = TraceByReturningC (\ s -> (alg s \/ eff . handleState s runTraceByReturningC) op)
-    where alg s (Trace m k) = runTraceByReturningC k (m : s)
+  eff op = TraceByReturningC (\ s -> handleSum
+    (eff . handleState s runTraceByReturningC)
+    (\ (Trace m k) -> runTraceByReturningC k (m : s)) op)
 
 
 -- $setup

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -55,8 +55,7 @@ newtype TraceByIgnoringC m a = TraceByIgnoringC { runTraceByIgnoringC :: m a }
 
 instance Carrier sig m => Carrier (Trace :+: sig) (TraceByIgnoringC m) where
   ret = TraceByIgnoringC . ret
-  eff = alg \/ (TraceByIgnoringC . eff . handlePure runTraceByIgnoringC)
-    where alg (Trace _ k) = k
+  eff = handleSum (TraceByIgnoringC . eff . handlePure runTraceByIgnoringC) (\ (Trace _ k) -> k)
 
 
 -- | Run a 'Trace' effect, returning all traces as a list.

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -44,8 +44,9 @@ newtype TraceByPrintingC m a = TraceByPrintingC { runTraceByPrintingC :: m a }
 
 instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (TraceByPrintingC m) where
   ret = TraceByPrintingC . ret
-  eff = TraceByPrintingC . (alg \/ eff . handlePure runTraceByPrintingC)
-    where alg (Trace s k) = liftIO (hPutStrLn stderr s) *> runTraceByPrintingC k
+  eff = TraceByPrintingC . handleSum
+    (eff . handlePure runTraceByPrintingC)
+    (\ (Trace s k) -> liftIO (hPutStrLn stderr s) *> runTraceByPrintingC k)
 
 
 -- | Run a 'Trace' effect, ignoring all traces.

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -58,7 +58,7 @@ newtype TraceByIgnoringC m a = TraceByIgnoringC { runTraceByIgnoringC :: m a }
 
 instance Carrier sig m => Carrier (Trace :+: sig) (TraceByIgnoringC m) where
   ret = TraceByIgnoringC . ret
-  eff = handleSum (TraceByIgnoringC . eff . handlePure runTraceByIgnoringC) (\ (Trace _ k) -> k)
+  eff = traceCont \/ TraceByIgnoringC . eff . handlePure runTraceByIgnoringC
 
 
 -- | Run a 'Trace' effect, returning all traces as a list.

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -47,9 +47,10 @@ newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig, Functor m) => Carrier (Writer w :+: sig) (WriterC w m) where
   ret a = WriterC (ret (mempty, a))
-  eff = WriterC . (alg \/ eff . handle (mempty, ()) (uncurry runWriter'))
-    where alg (Tell w k) = first (mappend w) <$> runWriterC k
-          runWriter' w = fmap (first (mappend w)) . runWriterC
+  eff = WriterC . handleSum
+    (eff . handle (mempty, ()) (uncurry runWriter'))
+    (\ (Tell w k) -> first (mappend w) <$> runWriterC k)
+    where runWriter' w = fmap (first (mappend w)) . runWriterC
 
 
 -- $setup


### PR DESCRIPTION
This PR defines a `handleSum` function which has better ergonomics than `\/`: not only does it have a pronounceable name, it has better error messaging when using typed holes than the erstwhile standard pattern of an algebra defined in the where clause.

- [x] Do we really want to keep `\/` around now?
- [x] Update the README to use `handleSum`.
- [x] :memo: `handleSum`.